### PR TITLE
fix: Set Accept header when getting a Building Block

### DIFF
--- a/client/buildingblock.go
+++ b/client/buildingblock.go
@@ -80,10 +80,12 @@ func (c *MeshStackProviderClient) urlForBuildingBlock(uuid string) *url.URL {
 
 func (c *MeshStackProviderClient) ReadBuildingBlock(uuid string) (*MeshBuildingBlock, error) {
 	targetUrl := c.urlForBuildingBlock(uuid)
+
 	req, err := http.NewRequest("GET", targetUrl.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", CONTENT_TYPE_BUILDING_BLOCK)
 
 	res, err := c.doAuthenticatedRequest(req)
 	if err != nil {


### PR DESCRIPTION
meshStack enforces the Accept header soon, so we have to make sure to always provide it