### PR TITLE
feat: update CI to enforce gofmt formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,25 @@ jobs:
       #   with:
       #     version: latest
 
+  format:
+    name: Go Format Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Check Go formatting
+        run: |
+          if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then
+            echo "The following files are not formatted correctly:"
+            gofmt -l .
+            echo "Please run 'gofmt -w .' (or configure your IDE to automatically run gofmt upon save) to fix formatting issues."
+            exit 1
+          fi
+
   generate:
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +73,7 @@ jobs:
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests
-    needs: build
+    needs: [build, format]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
This is how it looks like when the formatting isn't correct:

<img width="1201" height="653" alt="image" src="https://github.com/user-attachments/assets/618293d0-cedc-4764-9295-a8a3a15810e9" />

<img width="1198" height="543" alt="image" src="https://github.com/user-attachments/assets/80e92ae6-ae92-4b0e-a63b-dd57b257ff1b" />
