### PR TITLE
test: add cross-workspace BBD listing acceptance test

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,10 @@ func TestAccSomething(t *testing.T) {
 
 Always start Gradle services in the background with logs redirected to `/tmp/` files.
 The `./gradlew :*:start` tasks block forever (they run Spring Boot apps), so they must
-not be awaited. Use `nohup ... &` and verify health endpoints afterwards.
+not be awaited. Use `nohup ... &` and verify readiness via log output afterwards.
+
+Prefer log-based readiness checks over health endpoint polling — checking logs detects
+startup errors (exceptions, binding failures) immediately rather than silently waiting.
 
 ```bash
 # 1. Start infrastructure (MariaDB, RabbitMQ, Keycloak, RavenDB)
@@ -80,17 +83,27 @@ nohup ./gradlew :buildingblocks:manual-block-runner:start --console=plain > /tmp
 nohup ./gradlew :meshfed:replicator:replicator-api:start --console=plain > /tmp/replicator.log 2>&1 &
 
 # 3. Wait for ALL services to be ready before running tests
-#    meshfed-api: port 8080 (takes ~60-120s for first start)
-#    block-coordinator: port 8083
-#    replicator: port 7080
-#    manual-block-runner: no HTTP port (check log for "Started BlockRunnerApplicationKt")
-until curl -sf http://localhost:8080/mesh/info > /dev/null 2>&1; do sleep 5; done
+#    Check logs for "Started <AppName>" messages (takes ~60-120s for first start).
+#    Also watch for ERROR/Exception lines which indicate startup failures.
+until grep -q "Started ApplicationKt" /tmp/meshstack-api.log 2>/dev/null; do
+  grep -i "exception\|error\|fatal" /tmp/meshstack-api.log 2>/dev/null | tail -1 && break
+  sleep 5
+done
 echo "meshfed-api ready"
-until curl -sf http://localhost:8083/actuator/health > /dev/null 2>&1; do sleep 5; done
+until grep -q "Started BlockCoordinatorApiApplicationKt" /tmp/block-coordinator.log 2>/dev/null; do
+  grep -i "exception\|error\|fatal" /tmp/block-coordinator.log 2>/dev/null | tail -1 && break
+  sleep 5
+done
 echo "block-coordinator ready"
-until curl -sf http://localhost:7080/actuator/health > /dev/null 2>&1; do sleep 5; done
+until grep -q "Started ApplicationKt" /tmp/replicator.log 2>/dev/null; do
+  grep -i "exception\|error\|fatal" /tmp/replicator.log 2>/dev/null | tail -1 && break
+  sleep 5
+done
 echo "replicator ready"
-until grep -q "Started BlockRunnerApplicationKt" /tmp/manual-runner.log 2>/dev/null; do sleep 5; done
+until grep -q "Started BlockRunnerApplicationKt" /tmp/manual-runner.log 2>/dev/null; do
+  grep -i "exception\|error\|fatal" /tmp/manual-runner.log 2>/dev/null | tail -1 && break
+  sleep 5
+done
 echo "manual-runner ready"
 ```
 

--- a/client/buildingblock_definition.go
+++ b/client/buildingblock_definition.go
@@ -82,8 +82,9 @@ func newBuildingBlockDefinitionClient(ctx context.Context, httpClient *internal.
 
 func (c meshBuildingBlockDefinitionClient) List(ctx context.Context, workspaceIdentifier *string) ([]MeshBuildingBlockDefinition, error) {
 	var options []internal.RequestOption
+	options = append(options, internal.WithUrlQuery("includeAllPublished", "true"))
 	if workspaceIdentifier != nil {
-		options = append(options, internal.WithUrlQuery("workspaceIdentifier", *workspaceIdentifier))
+		options = append(options, internal.WithUrlQuery("ownedByWorkspace", *workspaceIdentifier))
 	}
 	return c.meshObject.List(ctx, options...)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,10 @@ import (
 
 var MinMeshStackVersion = version.MustParse("2026.10.0")
 
+// HttpError represents an HTTP error response with status code.
+// This error is returned when an HTTP request fails with a non-2XX status code.
+type HttpError = internal.HttpError
+
 type Client struct {
 	ApiKey                         MeshApiKeyClient
 	BuildingBlock                  MeshBuildingBlockClient

--- a/client/internal/http_client.go
+++ b/client/internal/http_client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,9 +14,26 @@ import (
 	"github.com/meshcloud/terraform-provider-meshstack/client/version"
 )
 
-var (
-	errNotFound = errors.New("request failed with status Not Found (404)")
-)
+// HttpError represents an HTTP error response with status code.
+// This error is returned when an HTTP request fails with a non-2XX status code.
+type HttpError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e HttpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Message)
+}
+
+// IsForbidden returns true if the error is a 403 Forbidden response.
+func (e HttpError) IsForbidden() bool {
+	return e.StatusCode == http.StatusForbidden
+}
+
+// IsNotFound returns true if the error is a 404 Not Found response.
+func (e HttpError) IsNotFound() bool {
+	return e.StatusCode == http.StatusNotFound
+}
 
 // HttpClient wraps [http.Client] with convenient request handling thanks to RequestOption.
 type HttpClient struct {
@@ -63,15 +79,11 @@ func (c *HttpClient) readBodyAndCheckSuccess(ctx context.Context, res *http.Resp
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return responseBody, nil
 	}
-	var errs []error
-	if res.StatusCode == http.StatusNotFound {
-		errs = append(errs, errNotFound)
+
+	return responseBody, HttpError{
+		StatusCode: res.StatusCode,
+		Message:    string(responseBody),
 	}
-	errs = append(errs,
-		fmt.Errorf("request failed with status %d (not 2XX successful)", res.StatusCode),
-		fmt.Errorf("error response: %s", string(responseBody)),
-	)
-	return responseBody, errors.Join(errs...)
 }
 
 func (c *HttpClient) buildRequest(ctx context.Context, method string, url url.URL, opts requestOptions) (*http.Request, error) {

--- a/client/internal/mesh_object_client.go
+++ b/client/internal/mesh_object_client.go
@@ -77,7 +77,7 @@ func (c MeshObjectClient[M]) meshObjectMimeType() string {
 // Get retrieves a meshObject by ID. Returns nil if not found.
 func (c MeshObjectClient[M]) Get(ctx context.Context, id string) (*M, error) {
 	body, err := c.doAuthorizedRequest(ctx, http.MethodGet, c.ApiUrl.JoinPath(id), withAccept(c.meshObjectMimeType()))
-	if errors.Is(err, errNotFound) {
+	if httpErr, ok := errors.AsType[HttpError](err); ok && httpErr.IsNotFound() {
 		return nil, nil
 	}
 	return unmarshalBody[M](body, err)

--- a/docs/data-sources/building_block_definitions.md
+++ b/docs/data-sources/building_block_definitions.md
@@ -4,12 +4,17 @@ page_title: "meshstack_building_block_definitions Data Source - terraform-provid
 subcategory: ""
 description: |-
   List building block definitions with optional workspace filter. Prefer this plural data source with one(...) for reusable wiring in examples. For each returned definition, this data source performs an additional API call to load all versions; use workspace_identifier to narrow scope where possible.
+  Cross-Workspace Access: When accessing building block definitions from workspaces other than your own using a workspace-scoped API key, the content_hash attribute will be null as it requires detailed version information that is not accessible without workspace permissions. The versions, version_latest, and version_latest_release attributes will still be populated with uuid, number, and state.
   ~> Preview: This resource is in preview. Breaking changes are possible without prior notice due to changes in the underlying meshStack preview API https://docs.meshcloud.io/api/technical-specifications#preview-endpoints or due to changes in this provider. Please ensure you are running the latest version of the provider and report any bugs via GitHub issues https://github.com/meshcloud/terraform-provider-meshstack/issues or via support@meshcloud.io.
 ---
 
 # meshstack_building_block_definitions (Data Source)
 
 List building block definitions with optional workspace filter. Prefer this plural data source with `one(...)` for reusable wiring in examples. For each returned definition, this data source performs an additional API call to load all versions; use `workspace_identifier` to narrow scope where possible. 
+
+**Cross-Workspace Access**: When accessing building block definitions from workspaces other than your own using a workspace-scoped API key, the `content_hash` attribute will be null as it requires detailed version information that is not accessible without workspace permissions. The `versions`, `version_latest`, and `version_latest_release` attributes will still be populated with uuid, number, and state.
+
+
 
 ~> **Preview:** This resource is in preview. Breaking changes are possible without prior notice due to changes in the underlying [meshStack preview API](https://docs.meshcloud.io/api/technical-specifications#preview-endpoints) or due to changes in this provider. Please ensure you are running the latest version of the provider and report any bugs via [GitHub issues](https://github.com/meshcloud/terraform-provider-meshstack/issues) or via support@meshcloud.io.
 
@@ -37,7 +42,7 @@ locals {
 
 ### Optional
 
-- `workspace_identifier` (String) Optional workspace identifier filter (maps to `workspaceIdentifier` query param).
+- `workspace_identifier` (String) Optional workspace identifier filter (maps to `ownedByWorkspace` query param).
 
 ### Read-Only
 
@@ -61,9 +66,12 @@ Read-Only:
 <a id="nestedatt--building_block_definitions--version_latest_release"></a>
 ### Nested Schema for `building_block_definitions.version_latest_release`
 
+Optional:
+
+- `content_hash` (String) Content hash of the version. Null when accessing cross-workspace definitions without sufficient permissions.
+
 Read-Only:
 
-- `content_hash` (String) Content hash of the version.
 - `number` (Number) Version number.
 - `state` (String) State of the version.
 - `uuid` (String) UUID of the version.
@@ -99,9 +107,12 @@ Read-Only:
 <a id="nestedatt--building_block_definitions--version_latest"></a>
 ### Nested Schema for `building_block_definitions.version_latest`
 
+Optional:
+
+- `content_hash` (String) Content hash of the version. Null when accessing cross-workspace definitions without sufficient permissions.
+
 Read-Only:
 
-- `content_hash` (String) Content hash of the version.
 - `number` (Number) Version number.
 - `state` (String) State of the version.
 - `uuid` (String) UUID of the version.
@@ -110,9 +121,12 @@ Read-Only:
 <a id="nestedatt--building_block_definitions--versions"></a>
 ### Nested Schema for `building_block_definitions.versions`
 
+Optional:
+
+- `content_hash` (String) Content hash of the version. Null when accessing cross-workspace definitions without sufficient permissions.
+
 Read-Only:
 
-- `content_hash` (String) Content hash of the version.
 - `number` (Number) Version number.
 - `state` (String) State of the version.
 - `uuid` (String) UUID of the version.

--- a/examples/data-sources/meshstack_building_block_definitions/test-support_other_provider.tf
+++ b/examples/data-sources/meshstack_building_block_definitions/test-support_other_provider.tf
@@ -1,0 +1,15 @@
+variable "apikey_client_id" {
+  type     = string
+  nullable = false
+}
+
+variable "apikey_client_secret" {
+  type      = string
+  nullable  = false
+  sensitive = true
+}
+
+provider "meshstack-other" {
+  apikey    = var.apikey_client_id
+  apisecret = var.apikey_client_secret
+}

--- a/internal/provider/acctest/testconfig/config.go
+++ b/internal/provider/acctest/testconfig/config.go
@@ -48,6 +48,13 @@ func (d DataSource) Config(t *testing.T) Config {
 	return newConfig(t, examples.DataSource.Read(t, d.Name, d.Suffix))
 }
 
+// TestSupportConfig loads a test-support .tf file for the data source. Fails the test on error.
+// The file is looked up as data-sources/meshstack_<name>/test-support<Suffix><extraSuffix>.tf.
+func (r DataSource) TestSupportConfig(t *testing.T, extraSuffix string) Config {
+	t.Helper()
+	return newConfig(t, examples.DataSource.Read(t, r.Name, "test-support", r.Suffix, extraSuffix))
+}
+
 // Config wraps a parsed *hclwrite.File. All Config methods return a new Config — the receiver is never mutated.
 // Call [Config.String] only at the test step boundary (i.e. when assigning to [resource.TestStep.Config]).
 type Config struct {

--- a/internal/provider/building_block_definitions_data_source.go
+++ b/internal/provider/building_block_definitions_data_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"cmp"
 	"context"
+	"errors"
 	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -52,10 +53,10 @@ type buildingBlockDefinitionDataSourceSpecModel struct {
 }
 
 type buildingBlockDefinitionDataSourceVersionRefModel struct {
-	Uuid        string `tfsdk:"uuid"`
-	Number      int64  `tfsdk:"number"`
-	State       string `tfsdk:"state"`
-	ContentHash string `tfsdk:"content_hash"`
+	Uuid        string  `tfsdk:"uuid"`
+	Number      int64   `tfsdk:"number"`
+	State       string  `tfsdk:"state"`
+	ContentHash *string `tfsdk:"content_hash"`
 }
 
 func (d *buildingBlockDefinitionsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -84,8 +85,9 @@ func (d *buildingBlockDefinitionsDataSource) Schema(_ context.Context, _ datasou
 			Computed:            true,
 		},
 		"content_hash": schema.StringAttribute{
-			MarkdownDescription: "Content hash of the version.",
+			MarkdownDescription: "Content hash of the version. Null when accessing cross-workspace definitions without sufficient permissions.",
 			Computed:            true,
+			Optional:            true,
 		},
 	}
 
@@ -93,10 +95,16 @@ func (d *buildingBlockDefinitionsDataSource) Schema(_ context.Context, _ datasou
 		MarkdownDescription: "List building block definitions with optional workspace filter. " +
 			"Prefer this plural data source with `one(...)` for reusable wiring in examples. " +
 			"For each returned definition, this data source performs an additional API call to load all versions; " +
-			"use `workspace_identifier` to narrow scope where possible. " + previewDisclaimer(),
+			"use `workspace_identifier` to narrow scope where possible. " +
+			"\n\n" +
+			"**Cross-Workspace Access**: When accessing building block definitions from workspaces other than your own " +
+			"using a workspace-scoped API key, the `content_hash` attribute will be null as it requires detailed version " +
+			"information that is not accessible without workspace permissions. The `versions`, `version_latest`, and " +
+			"`version_latest_release` attributes will still be populated with uuid, number, and state." +
+			"\n\n" + previewDisclaimer(),
 		Attributes: map[string]schema.Attribute{
 			"workspace_identifier": schema.StringAttribute{
-				MarkdownDescription: "Optional workspace identifier filter (maps to `workspaceIdentifier` query param).",
+				MarkdownDescription: "Optional workspace identifier filter (maps to `ownedByWorkspace` query param).",
 				Optional:            true,
 			},
 			"building_block_definitions": schema.ListNestedAttribute{
@@ -195,6 +203,18 @@ func (d *buildingBlockDefinitionsDataSource) Read(ctx context.Context, req datas
 		}
 
 		versions, err := d.meshBuildingBlockDefinitionVersionClient.List(ctx, *definition.Metadata.Uuid)
+
+		// Check if the error is a 403 Forbidden - if so, fall back to status.Versions
+		if httpErr, ok := errors.AsType[client.HttpError](err); ok && httpErr.IsForbidden() {
+			// Fall back to status.Versions from the definition (no content_hash available)
+			defModel := buildVersionRefsFromStatus(&resp.Diagnostics, definition)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			result = append(result, defModel)
+			continue
+		}
+
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to list building block definition versions",
@@ -238,6 +258,81 @@ func (d *buildingBlockDefinitionsDataSource) Read(ctx context.Context, req datas
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// buildVersionRefsFromStatus builds version refs from definition status when full version details are not accessible.
+// This is used as a fallback when the versions API returns 403 (cross-workspace access without permission).
+// Content hash will be empty since it requires full version spec which is not available in status.
+func buildVersionRefsFromStatus(diags *diag.Diagnostics, definition client.MeshBuildingBlockDefinition) buildingBlockDefinitionDataSourceModel {
+	if definition.Status == nil {
+		diags.AddError(
+			"Building block definition status missing",
+			"API returned a building block definition without status, which is required to build version references.",
+		)
+		return buildingBlockDefinitionDataSourceModel{}
+	}
+
+	status := definition.Status
+
+	// Convert status.Versions to version refs (no content_hash available)
+	versions := make([]buildingBlockDefinitionDataSourceVersionRefModel, len(status.Versions))
+	for i, v := range status.Versions {
+		versions[i] = buildingBlockDefinitionDataSourceVersionRefModel{
+			Uuid:        v.VersionUuid,
+			Number:      v.VersionNumber,
+			State:       string(v.State),
+			ContentHash: nil, // Not available without full version spec
+		}
+	}
+
+	// Sort versions ascending by number
+	slices.SortFunc(versions, func(a, b buildingBlockDefinitionDataSourceVersionRefModel) int {
+		return cmp.Compare(a.Number, b.Number)
+	})
+
+	// Build latest version ref
+	latestVersion := buildingBlockDefinitionDataSourceVersionRefModel{
+		Uuid:        status.LatestVersionUuid,
+		Number:      status.LatestVersion,
+		State:       findVersionState(status.Versions, status.LatestVersionUuid),
+		ContentHash: nil, // Not available without full version spec
+	}
+
+	// Build latest released version ref (if exists)
+	var latestReleasedVersion *buildingBlockDefinitionDataSourceVersionRefModel
+	if status.LatestReleasedVersionUuid != nil && status.LatestReleasedVersion != nil {
+		latestReleasedVersion = &buildingBlockDefinitionDataSourceVersionRefModel{
+			Uuid:        *status.LatestReleasedVersionUuid,
+			Number:      *status.LatestReleasedVersion,
+			State:       string(client.MeshBuildingBlockDefinitionVersionStateReleased.Unwrap()),
+			ContentHash: nil, // Not available without full version spec
+		}
+	}
+
+	return buildingBlockDefinitionDataSourceModel{
+		Metadata: buildingBlockDefinitionDataSourceMetadataModel{
+			Uuid:             *definition.Metadata.Uuid,
+			OwnedByWorkspace: definition.Metadata.OwnedByWorkspace,
+		},
+		Spec: buildingBlockDefinitionDataSourceSpecModel{
+			DisplayName: definition.Spec.DisplayName,
+			TargetType:  definition.Spec.TargetType,
+		},
+		Versions:             versions,
+		VersionLatest:        latestVersion,
+		VersionLatestRelease: latestReleasedVersion,
+		Ref:                  newBuildingBlockDefinitionRef(*definition.Metadata.Uuid),
+	}
+}
+
+// findVersionState finds the state of a version by UUID from the status versions list.
+func findVersionState(versions []client.MeshBuildingBlockDefinitionStatusVersion, uuid string) string {
+	for _, v := range versions {
+		if v.VersionUuid == uuid {
+			return string(v.State)
+		}
+	}
+	return ""
+}
+
 func convertBBDVersionRef(diags *diag.Diagnostics, field string, ref buildingBlockDefinitionVersionRef) buildingBlockDefinitionDataSourceVersionRefModel {
 	if ref.Uuid.IsUnknown() || ref.Number.IsUnknown() || ref.State.IsUnknown() || ref.ContentHash.IsUnknown() {
 		diags.AddError(
@@ -250,7 +345,7 @@ func convertBBDVersionRef(diags *diag.Diagnostics, field string, ref buildingBlo
 		Uuid:        ref.Uuid.Get(),
 		Number:      ref.Number.Get(),
 		State:       string(ref.State.Get()),
-		ContentHash: ref.ContentHash.Get(),
+		ContentHash: new(ref.ContentHash.Get()),
 	}
 }
 

--- a/internal/provider/building_block_definitions_data_source_test.go
+++ b/internal/provider/building_block_definitions_data_source_test.go
@@ -1,33 +1,36 @@
 package provider
 
 import (
+	"encoding/json"
 	"testing"
 
+	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/meshcloud/terraform-provider-meshstack/internal/provider/acctest/testconfig"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/provider/acctest/xknownvalue"
 )
 
 func TestAccBuildingBlockDefinitionsDataSource(t *testing.T) {
-	buildingBlockDefinitionConfig, buildingBlockDefinitionAddr := testconfig.BBDManual(t)
+	t.Run("simple state check", func(t *testing.T) {
+		buildingBlockDefinitionConfig, buildingBlockDefinitionAddr := testconfig.BBDManual(t)
 
-	config := testconfig.DataSource{Name: "building_block_definitions"}.Config(t).WithFirstBlock(
-		testconfig.Descend("workspace_identifier")(testconfig.SetAddr(buildingBlockDefinitionAddr, "metadata", "owned_by_workspace")),
-	).Join(buildingBlockDefinitionConfig)
+		var dataSourceAddress testconfig.Traversal
+		config := testconfig.DataSource{Name: "building_block_definitions"}.Config(t).WithFirstBlock(
+			testconfig.ExtractAddress(&dataSourceAddress),
+			testconfig.Descend("workspace_identifier")(testconfig.SetAddr(buildingBlockDefinitionAddr, "metadata", "owned_by_workspace")),
+		).Join(buildingBlockDefinitionConfig)
 
-	addr := testconfig.Traversal{"data.meshstack_building_block_definitions", "example"}
-
-	ApplyAndTest(t, resource.TestCase{
-		Steps: []resource.TestStep{
+		ApplyAndTest(t, resource.TestCase{Steps: []resource.TestStep{
 			{
 				Config: config.String(),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(addr.String(), tfjsonpath.New("workspace_identifier"), xknownvalue.NotEmptyString()),
-					statecheck.ExpectKnownValue(addr.String(), tfjsonpath.New("building_block_definitions"), knownvalue.ListExact([]knownvalue.Check{
+					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("workspace_identifier"), xknownvalue.NotEmptyString()),
+					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("building_block_definitions"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectPartial(map[string]knownvalue.Check{
 							"metadata": knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"uuid":               xknownvalue.NotEmptyString(),
@@ -60,6 +63,99 @@ func TestAccBuildingBlockDefinitionsDataSource(t *testing.T) {
 					})),
 				},
 			},
-		},
+		}})
 	})
+
+	t.Run("cross-workspace listing", func(t *testing.T) {
+		if IsMockClientTest() {
+			t.Skip("cross-workspace test requires real permission boundaries")
+		}
+
+		buildingBlockDefinitionConfig, buildingBlockDefinitionAddr := testconfig.BBDManual(t)
+
+		// AS the BBDManual above already creates an "example" workspace, we need to rename the other workspace
+		// and extract its correct address as well.
+		// This other workspace will hold the API key used to list the BBD cross
+		var otherWorkspaceAddr testconfig.Traversal
+		otherWorkspaceConfig, _ := testconfig.Workspace(t)
+		otherWorkspaceConfig = otherWorkspaceConfig.WithFirstBlock(
+			testconfig.RenameKey("other"),
+			testconfig.ExtractAddress(&otherWorkspaceAddr),
+		)
+		apiKeyConfig, apiKeyAddr := testconfig.ApiKey(t, otherWorkspaceAddr)
+		apiKeyConfig = apiKeyConfig.WithFirstBlock(
+			testconfig.Descend("spec", "permissions")(testconfig.SetRawExpr(`["BUILDINGBLOCKDEFINITION_LIST"]`)),
+		)
+
+		supportConfig := buildingBlockDefinitionConfig.WithFirstBlock(
+			testconfig.Descend("version_spec", "draft")(testconfig.SetValue(cty.False)),
+		).Join(
+			otherWorkspaceConfig,
+			apiKeyConfig,
+		)
+
+		var dataSourceAddress testconfig.Traversal
+		example := testconfig.DataSource{Name: "building_block_definitions"}
+		config := example.Config(t).WithFirstBlock(
+			testconfig.ExtractAddress(&dataSourceAddress),
+			testconfig.Descend("workspace_identifier")(testconfig.SetAddr(buildingBlockDefinitionAddr, "metadata", "owned_by_workspace")),
+			// provider alias meshstack-other has hardcoded config in _other_provider test support file with restricted apikey
+			testconfig.Descend("provider")(testconfig.SetRawExpr("meshstack-other")),
+		).Join(
+			// keep the support config as is (containing the BBD to be read)
+			supportConfig,
+			// but make the data source use a different provider using the api key from the other workspace
+			// (credentials are passed in as variables in the second step)
+			example.TestSupportConfig(t, "_other_provider"),
+		)
+
+		var apiKeyClientId, apiKeyClientSecret lazyVariable
+		s := supportConfig.String()
+		ApplyAndTest(t, resource.TestCase{Steps: []resource.TestStep{
+			{
+				Config: s,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(buildingBlockDefinitionAddr.String(), tfjsonpath.New("version_latest_release").AtMapKey("state"), knownvalue.StringExact("RELEASED")),
+					statecheck.ExpectKnownValue(apiKeyAddr.String(), tfjsonpath.New("status").AtMapKey("client_id"), xknownvalue.NotEmptyString(func(clientId string) error {
+						apiKeyClientId = lazyVariable(clientId)
+						return nil
+					})),
+					statecheck.ExpectKnownValue(apiKeyAddr.String(), tfjsonpath.New("status").AtMapKey("client_secret"), xknownvalue.NotEmptyString(func(clientSecret string) error {
+						apiKeyClientSecret = lazyVariable(clientSecret)
+						return nil
+					})),
+				},
+			},
+			{
+				Config: config.String(),
+				ConfigVariables: tfconfig.Variables{
+					// variables are hard-coded in test support file
+					"apikey_client_id":     &apiKeyClientId,
+					"apikey_client_secret": &apiKeyClientSecret,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("building_block_definitions"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(func() map[string]knownvalue.Check {
+							versionRef := knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"uuid":         xknownvalue.NotEmptyString(),
+								"state":        knownvalue.StringExact("RELEASED"),
+								"content_hash": knownvalue.Null(),
+							})
+							return map[string]knownvalue.Check{
+								"version_latest":         versionRef,
+								"version_latest_release": versionRef,
+								"versions":               knownvalue.ListExact([]knownvalue.Check{versionRef}),
+							}
+						}()),
+					})),
+				},
+			},
+		}})
+	})
+}
+
+type lazyVariable string
+
+func (l *lazyVariable) MarshalJSON() ([]byte, error) {
+	return json.Marshal(*l)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,12 +38,12 @@ type MeshStackProviderModel struct {
 	ApiToken  types.String `tfsdk:"apitoken"`
 }
 
-func (p *MeshStackProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+func (p *MeshStackProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "meshstack"
 	resp.Version = p.version
 }
 
-func (p *MeshStackProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+func (p *MeshStackProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
@@ -162,7 +162,7 @@ func newProviderClient(ctx context.Context, data MeshStackProviderModel, provide
 	return
 }
 
-func (p *MeshStackProvider) Resources(ctx context.Context) []func() resource.Resource {
+func (p *MeshStackProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewProjectResource,
 		NewTenantResource,
@@ -186,7 +186,7 @@ func (p *MeshStackProvider) Resources(ctx context.Context) []func() resource.Res
 	}
 }
 
-func (p *MeshStackProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+func (p *MeshStackProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewBuildingBlockDataSource,
 		NewBuildingBlockV2DataSource,
@@ -212,7 +212,7 @@ func (p *MeshStackProvider) DataSources(ctx context.Context) []func() datasource
 	}
 }
 
-func (p *MeshStackProvider) Functions(ctx context.Context) []func() function.Function {
+func (p *MeshStackProvider) Functions(_ context.Context) []func() function.Function {
 	return []func() function.Function{
 		NewLoadImageFileFunction,
 		NewLoadFileFunction,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -22,7 +22,8 @@ import (
 // reattach.
 func ProviderFactoriesForTest(opts ...providerOption) map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){
-		"meshstack": providerserver.NewProtocol6WithError(New("test", opts...)()),
+		"meshstack":       providerserver.NewProtocol6WithError(New("test", opts...)()),
+		"meshstack-other": providerserver.NewProtocol6WithError(New("test-other", opts...)()),
 	}
 }
 


### PR DESCRIPTION
## Summary

Add acceptance test verifying that the `meshstack_building_block_definitions` data source can discover building block definitions from other workspaces using a limited API key.

## Changes

- Added cross-workspace listing test step using a second provider (`meshstack-other`) with a workspace-scoped API key
- Verifies that released+published BBDs are visible across workspace boundaries
- Uses `BUILDINGBLOCKDEFINITION_LIST` permission on the limited API key

## PR Stack

This PR sits on top of #158 (`feature/api-key-resource`). Merge #158 first.

## Related

- Backend PR: meshcloud/meshfed-release#9921
- BoldDesk: BD-2402