### PR TITLE
feat: adapt building_block_v2 to moved createdOn field in upstream API

### DIFF
--- a/client/buildingblock_v2.go
+++ b/client/buildingblock_v2.go
@@ -24,11 +24,8 @@ type MeshBuildingBlockV2 struct {
 }
 
 type MeshBuildingBlockV2Metadata struct {
-	Uuid                string  `json:"uuid" tfsdk:"uuid"`
-	OwnedByWorkspace    string  `json:"ownedByWorkspace" tfsdk:"owned_by_workspace"`
-	CreatedOn           string  `json:"createdOn" tfsdk:"created_on"`
-	MarkedForDeletionOn *string `json:"markedForDeletionOn" tfsdk:"marked_for_deletion_on"`
-	MarkedForDeletionBy *string `json:"markedForDeletionBy" tfsdk:"marked_for_deletion_by"`
+	Uuid             string `json:"uuid" tfsdk:"uuid"`
+	OwnedByWorkspace string `json:"ownedByWorkspace" tfsdk:"owned_by_workspace"`
 }
 
 type MeshBuildingBlockV2Spec struct {
@@ -54,10 +51,18 @@ type MeshBuildingBlockV2Create struct {
 	Spec MeshBuildingBlockV2Spec `json:"spec" tfsdk:"spec"`
 }
 
+type MeshBuildingBlockV2Lifecycle struct {
+	State               string  `json:"state" tfsdk:"state"`
+	CreatedOn           string  `json:"createdOn" tfsdk:"created_on"`
+	MarkedForDeletionOn *string `json:"markedForDeletionOn" tfsdk:"marked_for_deletion_on"`
+	MarkedForDeletionBy *string `json:"markedForDeletionBy" tfsdk:"marked_for_deletion_by"`
+}
+
 type MeshBuildingBlockV2Status struct {
-	Status     string                `json:"status" tfsdk:"status"`
-	Outputs    []MeshBuildingBlockIO `json:"outputs" tfsdk:"outputs"`
-	ForcePurge bool                  `json:"forcePurge" tfsdk:"force_purge"`
+	Status     string                       `json:"status" tfsdk:"status"`
+	Outputs    []MeshBuildingBlockIO        `json:"outputs" tfsdk:"outputs"`
+	ForcePurge bool                         `json:"forcePurge" tfsdk:"force_purge"`
+	Lifecycle  MeshBuildingBlockV2Lifecycle `json:"lifecycle" tfsdk:"lifecycle"`
 }
 
 type MeshBuildingBlockV2Client interface {

--- a/docs/data-sources/building_block_v2.md
+++ b/docs/data-sources/building_block_v2.md
@@ -44,9 +44,6 @@ Required:
 
 Read-Only:
 
-- `created_on` (String) Timestamp of building block creation.
-- `marked_for_deletion_by` (String) For deleted building blocks: user who requested deletion.
-- `marked_for_deletion_on` (String) For deleted building blocks: timestamp of deletion.
 - `owned_by_workspace` (String) The workspace containing this building block.
 
 
@@ -110,8 +107,20 @@ Read-Only:
 Read-Only:
 
 - `force_purge` (Boolean) Indicates whether an operator has requested purging of this Building Block.
+- `lifecycle` (Attributes) Lifecycle information for this Building Block. (see [below for nested schema](#nestedatt--status--lifecycle))
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
 - `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.
+
+<a id="nestedatt--status--lifecycle"></a>
+### Nested Schema for `status.lifecycle`
+
+Read-Only:
+
+- `created_on` (String) Timestamp of building block creation.
+- `marked_for_deletion_by` (String) For deleted building blocks: user who requested deletion.
+- `marked_for_deletion_on` (String) For deleted building blocks: timestamp of deletion.
+- `state` (String) Lifecycle state of the building block.
+
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/docs/resources/building_block_v2.md
+++ b/docs/resources/building_block_v2.md
@@ -149,9 +149,6 @@ Read-Only:
 
 Read-Only:
 
-- `created_on` (String) Timestamp of building block creation.
-- `marked_for_deletion_by` (String) For deleted building blocks: user who requested deletion.
-- `marked_for_deletion_on` (String) For deleted building blocks: timestamp of deletion.
 - `owned_by_workspace` (String) The workspace containing this building block.
 - `uuid` (String) UUID which uniquely identifies the building block.
 
@@ -162,8 +159,20 @@ Read-Only:
 Read-Only:
 
 - `force_purge` (Boolean) Indicates whether an operator has requested purging of this Building Block.
+- `lifecycle` (Attributes) Lifecycle information for this Building Block. (see [below for nested schema](#nestedatt--status--lifecycle))
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
 - `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.
+
+<a id="nestedatt--status--lifecycle"></a>
+### Nested Schema for `status.lifecycle`
+
+Read-Only:
+
+- `created_on` (String) Timestamp of building block creation.
+- `marked_for_deletion_by` (String) For deleted building blocks: user who requested deletion.
+- `marked_for_deletion_on` (String) For deleted building blocks: timestamp of deletion.
+- `state` (String) Lifecycle state of the building block.
+
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/internal/clientmock/mock_buildingblock_v2.go
+++ b/internal/clientmock/mock_buildingblock_v2.go
@@ -38,12 +38,15 @@ func (m MeshBuildingBlockV2Client) Create(_ context.Context, bb *client.MeshBuil
 		Metadata: client.MeshBuildingBlockV2Metadata{
 			Uuid:             id,
 			OwnedByWorkspace: ownedByWorkspace,
-			CreatedOn:        time.Now().UTC().Format(time.RFC3339),
 		},
 		Spec: bb.Spec,
 		Status: client.MeshBuildingBlockV2Status{
 			Status:  client.BUILDING_BLOCK_STATUS_SUCCEEDED,
 			Outputs: make([]client.MeshBuildingBlockIO, 0),
+			Lifecycle: client.MeshBuildingBlockV2Lifecycle{
+				State:     "ACTIVE",
+				CreatedOn: time.Now().UTC().Format(time.RFC3339),
+			},
 		},
 	}
 

--- a/internal/provider/building_block_v2_data_source.go
+++ b/internal/provider/building_block_v2_data_source.go
@@ -48,18 +48,6 @@ func (d *buildingBlockV2DataSource) Schema(ctx context.Context, req datasource.S
 						MarkdownDescription: "The workspace containing this building block.",
 						Computed:            true,
 					},
-					"created_on": schema.StringAttribute{
-						MarkdownDescription: "Timestamp of building block creation.",
-						Computed:            true,
-					},
-					"marked_for_deletion_on": schema.StringAttribute{
-						MarkdownDescription: "For deleted building blocks: timestamp of deletion.",
-						Computed:            true,
-					},
-					"marked_for_deletion_by": schema.StringAttribute{
-						MarkdownDescription: "For deleted building blocks: user who requested deletion.",
-						Computed:            true,
-					},
 				},
 			},
 
@@ -146,6 +134,28 @@ func (d *buildingBlockV2DataSource) Schema(ctx context.Context, req datasource.S
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),
+					"lifecycle": schema.SingleNestedAttribute{
+						MarkdownDescription: "Lifecycle information for this Building Block.",
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"state": schema.StringAttribute{
+								MarkdownDescription: "Lifecycle state of the building block.",
+								Computed:            true,
+							},
+							"created_on": schema.StringAttribute{
+								MarkdownDescription: "Timestamp of building block creation.",
+								Computed:            true,
+							},
+							"marked_for_deletion_on": schema.StringAttribute{
+								MarkdownDescription: "For deleted building blocks: timestamp of deletion.",
+								Computed:            true,
+							},
+							"marked_for_deletion_by": schema.StringAttribute{
+								MarkdownDescription: "For deleted building blocks: user who requested deletion.",
+								Computed:            true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -199,6 +209,7 @@ func (d *buildingBlockV2DataSource) Read(ctx context.Context, req datasource.Rea
 	// Set all status values except for outputs
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("status").AtName("status"), bb.Status.Status)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("status").AtName("force_purge"), bb.Status.ForcePurge)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("status").AtName("lifecycle"), bb.Status.Lifecycle)...)
 
 	// Read outputs
 	outputs := make(map[string]buildingBlockOutputModel)

--- a/internal/provider/building_block_v2_resource.go
+++ b/internal/provider/building_block_v2_resource.go
@@ -66,18 +66,6 @@ func (r *buildingBlockV2Resource) Schema(ctx context.Context, req resource.Schem
 						MarkdownDescription: "The workspace containing this building block.",
 						Computed:            true,
 					},
-					"created_on": schema.StringAttribute{
-						MarkdownDescription: "Timestamp of building block creation.",
-						Computed:            true,
-					},
-					"marked_for_deletion_on": schema.StringAttribute{
-						MarkdownDescription: "For deleted building blocks: timestamp of deletion.",
-						Computed:            true,
-					},
-					"marked_for_deletion_by": schema.StringAttribute{
-						MarkdownDescription: "For deleted building blocks: user who requested deletion.",
-						Computed:            true,
-					},
 				},
 			},
 
@@ -186,6 +174,28 @@ func (r *buildingBlockV2Resource) Schema(ctx context.Context, req resource.Schem
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),
+					"lifecycle": schema.SingleNestedAttribute{
+						MarkdownDescription: "Lifecycle information for this Building Block.",
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"state": schema.StringAttribute{
+								MarkdownDescription: "Lifecycle state of the building block.",
+								Computed:            true,
+							},
+							"created_on": schema.StringAttribute{
+								MarkdownDescription: "Timestamp of building block creation.",
+								Computed:            true,
+							},
+							"marked_for_deletion_on": schema.StringAttribute{
+								MarkdownDescription: "For deleted building blocks: timestamp of deletion.",
+								Computed:            true,
+							},
+							"marked_for_deletion_by": schema.StringAttribute{
+								MarkdownDescription: "For deleted building blocks: user who requested deletion.",
+								Computed:            true,
+							},
+						},
+					},
 				},
 			},
 			"wait_for_completion": schema.BoolAttribute{
@@ -366,6 +376,7 @@ func setStateFromResponseV2(ctx context.Context, state *tfsdk.State, bb *client.
 		return
 	}
 	diags.Append(state.SetAttribute(ctx, path.Root("status").AtName("outputs"), outputs)...)
+	diags.Append(state.SetAttribute(ctx, path.Root("status").AtName("lifecycle"), bb.Status.Lifecycle)...)
 
 	return diags
 }


### PR DESCRIPTION
The meshStack API has moved the building block creation timestamp from
metadata.createdOn to status.lifecycle.createdOn. This change updates the
Terraform provider to reflect the new API structure by:

Note: Existing Terraform state will need a refresh after upgrading the
provider to migrate from the old path to the new one.
