### PR TITLE
fix: use types.List instead of []types.String for options fields

### DIFF
--- a/internal/provider/tag_definition_resource.go
+++ b/internal/provider/tag_definition_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/modifiers/tagdefinitionmodifier"
@@ -104,7 +103,7 @@ func (r *tagDefinitionResource) ValidateConfig(ctx context.Context, req resource
 
 	if valueType.SingleSelect != nil && !valueType.SingleSelect.DefaultValue.IsNull() && !valueType.SingleSelect.DefaultValue.IsUnknown() {
 		defaultValue := valueType.SingleSelect.DefaultValue.ValueString()
-		options := extractStringValues(valueType.SingleSelect.Options)
+		options := extractStringValuesFromList(ctx, valueType.SingleSelect.Options)
 		if !slices.Contains(options, defaultValue) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("spec").AtName("value_type").AtName("single_select").AtName("default_value"),
@@ -114,9 +113,9 @@ func (r *tagDefinitionResource) ValidateConfig(ctx context.Context, req resource
 		}
 	}
 
-	if valueType.MultiSelect != nil && valueType.MultiSelect.DefaultValue != nil && len(valueType.MultiSelect.DefaultValue) > 0 {
-		defaultValues := extractStringValues(valueType.MultiSelect.DefaultValue)
-		options := extractStringValues(valueType.MultiSelect.Options)
+	if valueType.MultiSelect != nil && !valueType.MultiSelect.DefaultValue.IsNull() && !valueType.MultiSelect.DefaultValue.IsUnknown() {
+		defaultValues := extractStringValuesFromList(ctx, valueType.MultiSelect.DefaultValue)
+		options := extractStringValuesFromList(ctx, valueType.MultiSelect.Options)
 
 		for _, dv := range defaultValues {
 			if !slices.Contains(options, dv) {
@@ -303,13 +302,13 @@ type tagValueNumber struct {
 }
 
 type tagValueSingleSelect struct {
-	Options      []types.String `json:"options,omitempty" tfsdk:"options"`
-	DefaultValue types.String   `json:"defaultValue" tfsdk:"default_value"`
+	Options      types.List   `json:"options,omitempty" tfsdk:"options"`
+	DefaultValue types.String `json:"defaultValue" tfsdk:"default_value"`
 }
 
 type tagValueMultiSelect struct {
-	Options      []types.String `json:"options,omitempty" tfsdk:"options"`
-	DefaultValue []types.String `json:"defaultValue,omitempty" tfsdk:"default_value"`
+	Options      types.List `json:"options,omitempty" tfsdk:"options"`
+	DefaultValue types.List `json:"defaultValue,omitempty" tfsdk:"default_value"`
 }
 
 // Create creates the resource and sets the initial Terraform state.
@@ -322,7 +321,7 @@ func (r *tagDefinitionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	valueType := buildValueType(spec.ValueType)
+	valueType := buildValueType(ctx, spec.ValueType)
 
 	name := spec.TargetKind.ValueString() + "." + spec.Key.ValueString()
 
@@ -357,15 +356,20 @@ func (r *tagDefinitionResource) Create(ctx context.Context, req resource.CreateR
 	resp.Diagnostics.Append(diags...)
 }
 
-func extractStringValues(values []basetypes.StringValue) []string {
-	result := make([]string, len(values))
-	for i, v := range values {
+func extractStringValuesFromList(ctx context.Context, list types.List) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	elements := make([]types.String, 0, len(list.Elements()))
+	list.ElementsAs(ctx, &elements, false)
+	result := make([]string, len(elements))
+	for i, v := range elements {
 		result[i] = v.ValueString()
 	}
 	return result
 }
 
-func buildValueType(valueType tagDefinitionValueType) client.MeshTagDefinitionValueType {
+func buildValueType(ctx context.Context, valueType tagDefinitionValueType) client.MeshTagDefinitionValueType {
 	var result client.MeshTagDefinitionValueType
 
 	if valueType.String != nil {
@@ -396,17 +400,18 @@ func buildValueType(valueType tagDefinitionValueType) client.MeshTagDefinitionVa
 
 	if valueType.SingleSelect != nil {
 		result.SingleSelect = &client.TagValueSingleSelect{
-			Options:      extractStringValues(valueType.SingleSelect.Options),
+			Options:      extractStringValuesFromList(ctx, valueType.SingleSelect.Options),
 			DefaultValue: valueType.SingleSelect.DefaultValue.ValueStringPointer(),
 		}
 	}
 
 	if valueType.MultiSelect != nil {
 		result.MultiSelect = &client.TagValueMultiSelect{
-			Options: extractStringValues(valueType.MultiSelect.Options),
+			Options: extractStringValuesFromList(ctx, valueType.MultiSelect.Options),
 		}
-		if valueType.MultiSelect.DefaultValue != nil {
-			result.MultiSelect.DefaultValue = new(extractStringValues(valueType.MultiSelect.DefaultValue))
+		if !valueType.MultiSelect.DefaultValue.IsNull() && !valueType.MultiSelect.DefaultValue.IsUnknown() {
+			defaultValues := extractStringValuesFromList(ctx, valueType.MultiSelect.DefaultValue)
+			result.MultiSelect.DefaultValue = &defaultValues
 		}
 	}
 
@@ -446,7 +451,7 @@ func (r *tagDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	valueType := buildValueType(spec.ValueType)
+	valueType := buildValueType(ctx, spec.ValueType)
 	name := spec.TargetKind.ValueString() + "." + spec.Key.ValueString()
 
 	update := client.MeshTagDefinition{

--- a/internal/provider/tag_definition_resource.go
+++ b/internal/provider/tag_definition_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -103,7 +104,11 @@ func (r *tagDefinitionResource) ValidateConfig(ctx context.Context, req resource
 
 	if valueType.SingleSelect != nil && !valueType.SingleSelect.DefaultValue.IsNull() && !valueType.SingleSelect.DefaultValue.IsUnknown() {
 		defaultValue := valueType.SingleSelect.DefaultValue.ValueString()
-		options := extractStringValuesFromList(ctx, valueType.SingleSelect.Options)
+		options, diags := extractStringValuesFromList(ctx, valueType.SingleSelect.Options)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		if !slices.Contains(options, defaultValue) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("spec").AtName("value_type").AtName("single_select").AtName("default_value"),
@@ -114,8 +119,16 @@ func (r *tagDefinitionResource) ValidateConfig(ctx context.Context, req resource
 	}
 
 	if valueType.MultiSelect != nil && !valueType.MultiSelect.DefaultValue.IsNull() && !valueType.MultiSelect.DefaultValue.IsUnknown() {
-		defaultValues := extractStringValuesFromList(ctx, valueType.MultiSelect.DefaultValue)
-		options := extractStringValuesFromList(ctx, valueType.MultiSelect.Options)
+		defaultValues, diags := extractStringValuesFromList(ctx, valueType.MultiSelect.DefaultValue)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		options, diags := extractStringValuesFromList(ctx, valueType.MultiSelect.Options)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		for _, dv := range defaultValues {
 			if !slices.Contains(options, dv) {
@@ -321,7 +334,11 @@ func (r *tagDefinitionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	valueType := buildValueType(ctx, spec.ValueType)
+	valueType, diags := buildValueType(ctx, spec.ValueType)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	name := spec.TargetKind.ValueString() + "." + spec.Key.ValueString()
 
@@ -356,21 +373,18 @@ func (r *tagDefinitionResource) Create(ctx context.Context, req resource.CreateR
 	resp.Diagnostics.Append(diags...)
 }
 
-func extractStringValuesFromList(ctx context.Context, list types.List) []string {
+func extractStringValuesFromList(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
 	if list.IsNull() || list.IsUnknown() {
-		return nil
+		return nil, nil
 	}
-	elements := make([]types.String, 0, len(list.Elements()))
-	list.ElementsAs(ctx, &elements, false)
-	result := make([]string, len(elements))
-	for i, v := range elements {
-		result[i] = v.ValueString()
-	}
-	return result
+	var result []string
+	diags := list.ElementsAs(ctx, &result, false)
+	return result, diags
 }
 
-func buildValueType(ctx context.Context, valueType tagDefinitionValueType) client.MeshTagDefinitionValueType {
+func buildValueType(ctx context.Context, valueType tagDefinitionValueType) (client.MeshTagDefinitionValueType, diag.Diagnostics) {
 	var result client.MeshTagDefinitionValueType
+	var diags diag.Diagnostics
 
 	if valueType.String != nil {
 		result.String = &client.TagValueString{
@@ -399,23 +413,28 @@ func buildValueType(ctx context.Context, valueType tagDefinitionValueType) clien
 	}
 
 	if valueType.SingleSelect != nil {
+		options, d := extractStringValuesFromList(ctx, valueType.SingleSelect.Options)
+		diags.Append(d...)
 		result.SingleSelect = &client.TagValueSingleSelect{
-			Options:      extractStringValuesFromList(ctx, valueType.SingleSelect.Options),
+			Options:      options,
 			DefaultValue: valueType.SingleSelect.DefaultValue.ValueStringPointer(),
 		}
 	}
 
 	if valueType.MultiSelect != nil {
+		options, d := extractStringValuesFromList(ctx, valueType.MultiSelect.Options)
+		diags.Append(d...)
 		result.MultiSelect = &client.TagValueMultiSelect{
-			Options: extractStringValuesFromList(ctx, valueType.MultiSelect.Options),
+			Options: options,
 		}
 		if !valueType.MultiSelect.DefaultValue.IsNull() && !valueType.MultiSelect.DefaultValue.IsUnknown() {
-			defaultValues := extractStringValuesFromList(ctx, valueType.MultiSelect.DefaultValue)
+			defaultValues, d := extractStringValuesFromList(ctx, valueType.MultiSelect.DefaultValue)
+			diags.Append(d...)
 			result.MultiSelect.DefaultValue = &defaultValues
 		}
 	}
 
-	return result
+	return result, diags
 }
 
 // Read refreshes the Terraform state with the latest data.
@@ -451,7 +470,11 @@ func (r *tagDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	valueType := buildValueType(ctx, spec.ValueType)
+	valueType, diags := buildValueType(ctx, spec.ValueType)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	name := spec.TargetKind.ValueString() + "." + spec.Key.ValueString()
 
 	update := client.MeshTagDefinition{

--- a/internal/provider/tag_definition_resource_test.go
+++ b/internal/provider/tag_definition_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -62,6 +63,77 @@ resource "meshstack_tag_definition" "single_select_local" {
 						knownvalue.StringExact("option_c"),
 					})),
 				},
+			},
+		},
+	})
+}
+
+// TestTagDefinitionResource_OptionsCoerceNumbersToStrings verifies that Terraform's
+// type system automatically coerces number literals to strings in a list(string)
+// context — options = [1, 2, 3] is accepted and stored as ["1", "2", "3"].
+// This coercion happens at the HCL evaluation layer before provider code is reached
+// There's nothing we can do about it, but we pin this (undesired) behavior here in the test.
+func TestTagDefinitionResource_OptionsCoerceNumbersToStrings(t *testing.T) {
+	keySuffix := acctest.RandString(8)
+	addr := "meshstack_tag_definition.single_select_numbers"
+
+	config := `
+resource "meshstack_tag_definition" "single_select_numbers" {
+  spec = {
+    target_kind  = "meshProject"
+    key          = "test-ss-numbers-` + keySuffix + `"
+    display_name = "Test Single Select Numbers"
+    value_type = {
+      single_select = {
+        options = [1, 2, 3]
+      }
+    }
+  }
+}
+`
+
+	ApplyAndTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("spec").AtMapKey("value_type").AtMapKey("single_select").AtMapKey("options"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.StringExact("1"),
+						knownvalue.StringExact("2"),
+						knownvalue.StringExact("3"),
+					})),
+				},
+			},
+		},
+	})
+}
+
+// TestTagDefinitionResource_OptionsRejectObjectElements verifies that the schema
+// enforces list(string) element type for options — an object element cannot be
+// coerced to string and must be rejected.
+func TestTagDefinitionResource_OptionsRejectObjectElements(t *testing.T) {
+	keySuffix := acctest.RandString(8)
+
+	config := `
+resource "meshstack_tag_definition" "invalid_options" {
+  spec = {
+    target_kind  = "meshProject"
+    key          = "test-invalid-elem-` + keySuffix + `"
+    display_name = "Test Invalid Element Type"
+    value_type = {
+      single_select = {
+        options = [{ not_a_string = true }]
+      }
+    }
+  }
+}
+`
+
+	ApplyAndTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Incorrect attribute value type|Invalid value for`),
 			},
 		},
 	})

--- a/internal/provider/tag_definition_resource_test.go
+++ b/internal/provider/tag_definition_resource_test.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
@@ -20,6 +22,45 @@ func TestAccTagDefinitionResource(t *testing.T) {
 				Config: config.String(),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(tagDefinitionAddr.String(), tfjsonpath.New("spec").AtMapKey("display_name"), xknownvalue.KnownStringWithPrefix("Example")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccTagDefinitionResource_SingleSelectWithLocalOptions(t *testing.T) {
+	keySuffix := acctest.RandString(8)
+	addr := "meshstack_tag_definition.single_select_local"
+
+	config := `
+locals {
+  tag_options = ["option_a", "option_b", "option_c"]
+}
+
+resource "meshstack_tag_definition" "single_select_local" {
+  spec = {
+    target_kind  = "meshProject"
+    key          = "test-ss-local-` + keySuffix + `"
+    display_name = "Test Single Select Local"
+    value_type = {
+      single_select = {
+        options = local.tag_options
+      }
+    }
+  }
+}
+`
+
+	ApplyAndTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("spec").AtMapKey("value_type").AtMapKey("single_select").AtMapKey("options"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.StringExact("option_a"),
+						knownvalue.StringExact("option_b"),
+						knownvalue.StringExact("option_c"),
+					})),
 				},
 			},
 		},


### PR DESCRIPTION
The tagValueSingleSelect and tagValueMultiSelect model structs used []types.String for their Options and DefaultValue fields. This caused "Value Conversion Error" when these fields received values not fully resolved at plan time (e.g., variable references), because the Terraform Plugin Framework cannot handle Go slices with unknown elements.

Changed to types.List which properly supports unknown/null semantics during the plan phase.

BD-2435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag definitions can derive single-select and multi-select options from Terraform locals for more flexible tag configs.
* **Bug Fixes**
  * Improved handling of null/unknown lists during validation and default assignment; numeric option values are coerced to strings and invalid objects are rejected.
* **Tests**
  * Added acceptance tests covering local-sourced options, numeric coercion, and rejection of invalid option elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->