### PR TITLE
fix: migrate building block target references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## UNRELEASED
+
+Requires meshStack 2026.22.0 or later (previously 2026.10.0).
+
+BREAKING CHANGES:
+- `meshstack_building_block_v2`: Renamed `target_ref.identifier` to `target_ref.name` to align with upstream API changes.
+  Update configurations to use `name` instead of `identifier` when specifying the target workspace.
+- `meshstack_workspace`: Renamed `ref.identifier` to `ref.name` to align with upstream API changes.
+  Update any references to the workspace's `ref` field to use `name` instead of `identifier`.
+
 ## v0.20.10
 
 FIXES:
@@ -7,12 +17,12 @@ FIXES:
 
 BREAKING CHANGES:
 - `meshstack_building_block_v2`: Building blocks in meshStack versions higher than v2026.20.0 are now soft-deleted instead of hard-deleted.
-  The Terraform provider has been updated to correctly detect soft-deleted building blocks by inspecting the 
-  lifecycle state. To ensure correct deletion detection, upgrade the Terraform provider when using meshStack 
+  The Terraform provider has been updated to correctly detect soft-deleted building blocks by inspecting the
+  lifecycle state. To ensure correct deletion detection, upgrade the Terraform provider when using meshStack
   versions higher than v2026.20.0.
 
 NOTE:
-- This version is backwards-compatible and can be used with older versions of meshStack. If you are using a meshStack version 
+- This version is backwards-compatible and can be used with older versions of meshStack. If you are using a meshStack version
   v2026.20.0 or lower, the provider will continue to work as expected with hard-deleted building blocks.
 
 ## v0.20.8

--- a/client/buildingblock_v2.go
+++ b/client/buildingblock_v2.go
@@ -45,9 +45,9 @@ type MeshBuildingBlockV2DefinitionVersionRef struct {
 }
 
 type MeshBuildingBlockV2TargetRef struct {
-	Kind       string  `json:"kind" tfsdk:"kind"`
-	Uuid       *string `json:"uuid" tfsdk:"uuid"`
-	Identifier *string `json:"identifier" tfsdk:"identifier"`
+	Kind string  `json:"kind" tfsdk:"kind"`
+	Uuid *string `json:"uuid" tfsdk:"uuid"`
+	Name *string `json:"name" tfsdk:"name"`
 }
 
 type MeshBuildingBlockV2Create struct {

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/meshcloud/terraform-provider-meshstack/client/version"
 )
 
-var MinMeshStackVersion = version.MustParse("2026.10.0")
+var MinMeshStackVersion = version.MustParse("2026.22.0")
 
 // HttpError represents an HTTP error response with status code.
 // This error is returned when an HTTP request fails with a non-2XX status code.

--- a/docs/data-sources/building_block_v2.md
+++ b/docs/data-sources/building_block_v2.md
@@ -95,8 +95,8 @@ Read-Only:
 
 Read-Only:
 
-- `identifier` (String) Identifier of the target workspace.
 - `kind` (String) Target kind for this building block, depends on building block definition type. One of `meshTenant`, `meshWorkspace`.
+- `name` (String) Identifier of the target workspace.
 - `uuid` (String) UUID of the target tenant.
 
 

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -51,8 +51,8 @@ Read-Only:
 
 Read-Only:
 
-- `identifier` (String) Identifier of the workspace.
 - `kind` (String) The kind of the object. Always `meshWorkspace`.
+- `name` (String) Identifier of the workspace.
 
 
 <a id="nestedatt--spec"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: |-
 
 The meshStack terraform provider is an open-source tool, licensed under the MPL-2.0, and is actively maintained by meshcloud GmbH. The provider exposes APIs of meshStack to manage resources as code.
 
-**Note:** This provider version requires meshStack version 2026.10.0 or higher. The provider automatically validates version compatibility during initialization.
+**Note:** This provider version requires meshStack version 2026.22.0 or higher. The provider automatically validates version compatibility during initialization.
 
 ## Dependency wiring patterns
 

--- a/docs/resources/building_block_v2.md
+++ b/docs/resources/building_block_v2.md
@@ -102,8 +102,8 @@ Required:
 
 Optional:
 
-- `identifier` (String) Identifier of the target workspace.
-- `uuid` (String) UUID of the target workspace or tenant.
+- `name` (String) Identifier of the target workspace.
+- `uuid` (String) UUID of the target tenant.
 
 
 <a id="nestedatt--spec--inputs"></a>

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -75,8 +75,8 @@ Optional:
 
 Read-Only:
 
-- `identifier` (String) Identifier of the workspace.
 - `kind` (String) The kind of the object. Always `meshWorkspace`.
+- `name` (String) Identifier of the workspace.
 
 ## Import
 

--- a/internal/clientmock/mock_buildingblock_v2.go
+++ b/internal/clientmock/mock_buildingblock_v2.go
@@ -29,8 +29,8 @@ func (m MeshBuildingBlockV2Client) Create(_ context.Context, bb *client.MeshBuil
 	id := uuid.NewString()
 
 	ownedByWorkspace := ""
-	if bb.Spec.TargetRef.Identifier != nil {
-		ownedByWorkspace = *bb.Spec.TargetRef.Identifier
+	if bb.Spec.TargetRef.Name != nil {
+		ownedByWorkspace = *bb.Spec.TargetRef.Name
 	}
 
 	created := &client.MeshBuildingBlockV2{

--- a/internal/provider/building_block_v2_data_source.go
+++ b/internal/provider/building_block_v2_data_source.go
@@ -84,10 +84,10 @@ func (d *buildingBlockV2DataSource) Schema(ctx context.Context, req datasource.S
 								Computed:            true,
 								Validators: []validator.String{stringvalidator.ExactlyOneOf(
 									path.MatchRelative().AtParent().AtName("uuid"),
-									path.MatchRelative().AtParent().AtName("identifier"),
+									path.MatchRelative().AtParent().AtName("name"),
 								)},
 							},
-							"identifier": schema.StringAttribute{
+							"name": schema.StringAttribute{
 								MarkdownDescription: "Identifier of the target workspace.",
 								Computed:            true,
 							},

--- a/internal/provider/building_block_v2_resource.go
+++ b/internal/provider/building_block_v2_resource.go
@@ -104,15 +104,15 @@ func (r *buildingBlockV2Resource) Schema(ctx context.Context, req resource.Schem
 								},
 							},
 							"uuid": schema.StringAttribute{
-								MarkdownDescription: "UUID of the target workspace or tenant.",
+								MarkdownDescription: "UUID of the target tenant.",
 								Optional:            true,
 								Default:             nil,
 								Validators: []validator.String{stringvalidator.ExactlyOneOf(
 									path.MatchRelative().AtParent().AtName("uuid"),
-									path.MatchRelative().AtParent().AtName("identifier"),
+									path.MatchRelative().AtParent().AtName("name"),
 								)},
 							},
-							"identifier": schema.StringAttribute{
+							"name": schema.StringAttribute{
 								MarkdownDescription: "Identifier of the target workspace.",
 								Optional:            true,
 								Default:             nil,

--- a/internal/provider/workspace_data_source.go
+++ b/internal/provider/workspace_data_source.go
@@ -44,7 +44,7 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						MarkdownDescription: "The kind of the object. Always `meshWorkspace`.",
 						Computed:            true,
 					},
-					"identifier": schema.StringAttribute{
+					"name": schema.StringAttribute{
 						MarkdownDescription: "Identifier of the workspace.",
 						Computed:            true,
 					},

--- a/internal/provider/workspace_data_source_test.go
+++ b/internal/provider/workspace_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccWorkspaceDataSource(t *testing.T) {
 				Config: config.String(),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("ref").AtMapKey("kind"), knownvalue.StringExact("meshWorkspace")),
-					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("ref").AtMapKey("identifier"), xknownvalue.NotEmptyString()),
+					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("ref").AtMapKey("name"), xknownvalue.NotEmptyString()),
 					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("metadata").AtMapKey("name"), xknownvalue.NotEmptyString()),
 					statecheck.ExpectKnownValue(dataSourceAddress.String(), tfjsonpath.New("spec").AtMapKey("display_name"), knownvalue.StringExact("My Workspace's Display Name")),
 				},

--- a/internal/provider/workspace_model.go
+++ b/internal/provider/workspace_model.go
@@ -10,16 +10,16 @@ type workspaceModel struct {
 }
 
 type workspaceRef struct {
-	Kind       string `tfsdk:"kind"`
-	Identifier string `tfsdk:"identifier"`
+	Kind string `tfsdk:"kind"`
+	Name string `tfsdk:"name"`
 }
 
 func newWorkspaceModel(workspace *client.MeshWorkspace) workspaceModel {
 	return workspaceModel{
 		MeshWorkspace: workspace,
 		Ref: workspaceRef{
-			Kind:       client.MeshObjectKind.Workspace,
-			Identifier: workspace.Metadata.Name,
+			Kind: client.MeshObjectKind.Workspace,
+			Name: workspace.Metadata.Name,
 		},
 	}
 }

--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -63,7 +63,7 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Computed:            true,
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
-					"identifier": schema.StringAttribute{
+					"name": schema.StringAttribute{
 						MarkdownDescription: "Identifier of the workspace.",
 						Computed:            true,
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},

--- a/internal/provider/workspace_resource_test.go
+++ b/internal/provider/workspace_resource_test.go
@@ -40,7 +40,7 @@ func TestAccWorkspace(t *testing.T) {
 
 					// Ref
 					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("ref").AtMapKey("kind"), knownvalue.StringExact("meshWorkspace")),
-					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("ref").AtMapKey("identifier"), xknownvalue.NotEmptyString()),
+					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("ref").AtMapKey("name"), xknownvalue.NotEmptyString()),
 				},
 			},
 			{
@@ -62,7 +62,7 @@ func TestAccWorkspace(t *testing.T) {
 					if rs == nil {
 						return "", fmt.Errorf("resource not found: %s", resourceAddress.String())
 					}
-					return rs.Primary.Attributes["ref.identifier"], nil
+					return rs.Primary.Attributes["ref.name"], nil
 				},
 				ResourceName: resourceAddress.String(),
 			},


### PR DESCRIPTION
CU-86c9uebcz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  - Reference fields renamed from `identifier` → `name` for workspace and building-block references; update your configurations.
  - Minimum meshStack version raised to 2026.22.0 (was 2026.10.0).

* **Documentation**
  - Docs updated to reflect the field renames and the new minimum version; upgrade note clarified for provider behavior detecting soft-deleted building blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->