### PR TITLE
fix: add lifecycle state tracking to building_block_v2

### DIFF
--- a/client/buildingblock_v2.go
+++ b/client/buildingblock_v2.go
@@ -15,6 +15,7 @@ const (
 	BUILDING_BLOCK_STATUS_IN_PROGRESS                 = "IN_PROGRESS"
 	BUILDING_BLOCK_STATUS_SUCCEEDED                   = "SUCCEEDED"
 	BUILDING_BLOCK_STATUS_FAILED                      = "FAILED"
+	BUILDING_BLOCK_LIFECYCLE_STATE_DELETED            = "DELETED"
 )
 
 type MeshBuildingBlockV2 struct {
@@ -51,10 +52,15 @@ type MeshBuildingBlockV2Create struct {
 	Spec MeshBuildingBlockV2Spec `json:"spec" tfsdk:"spec"`
 }
 
+type MeshBuildingBlockV2Lifecycle struct {
+	State string `json:"state" tfsdk:"state"`
+}
+
 type MeshBuildingBlockV2Status struct {
-	Status     string                `json:"status" tfsdk:"status"`
-	Outputs    []MeshBuildingBlockIO `json:"outputs" tfsdk:"outputs"`
-	ForcePurge bool                  `json:"forcePurge" tfsdk:"force_purge"`
+	Status     string                       `json:"status" tfsdk:"status"`
+	Outputs    []MeshBuildingBlockIO        `json:"outputs" tfsdk:"outputs"`
+	ForcePurge bool                         `json:"forcePurge" tfsdk:"force_purge"`
+	Lifecycle  MeshBuildingBlockV2Lifecycle `json:"lifecycle" tfsdk:"lifecycle"`
 }
 
 type MeshBuildingBlockV2Client interface {
@@ -105,6 +111,8 @@ func (bb *MeshBuildingBlockV2) CreateSuccessful() (done bool, err error) {
 func (bb *MeshBuildingBlockV2) DeletionSuccessful() (done bool, err error) {
 	switch {
 	case bb == nil:
+		done = true
+	case bb.Status.Lifecycle.State == BUILDING_BLOCK_LIFECYCLE_STATE_DELETED:
 		done = true
 	case bb.Status.Status == BUILDING_BLOCK_STATUS_FAILED:
 		err = fmt.Errorf("building block %s reached FAILED state during deletion. For more details, check the building block run logs in meshStack", bb.Metadata.Uuid)

--- a/client/buildingblock_v2.go
+++ b/client/buildingblock_v2.go
@@ -9,13 +9,15 @@ import (
 
 const (
 	// Building Block Status Constants.
-	BUILDING_BLOCK_STATUS_WAITING_FOR_DEPENDENT_INPUT = "WAITING_FOR_DEPENDENT_INPUT"
-	BUILDING_BLOCK_STATUS_WAITING_FOR_OPERATOR_INPUT  = "WAITING_FOR_OPERATOR_INPUT"
-	BUILDING_BLOCK_STATUS_PENDING                     = "PENDING"
-	BUILDING_BLOCK_STATUS_IN_PROGRESS                 = "IN_PROGRESS"
-	BUILDING_BLOCK_STATUS_SUCCEEDED                   = "SUCCEEDED"
-	BUILDING_BLOCK_STATUS_FAILED                      = "FAILED"
-	BUILDING_BLOCK_LIFECYCLE_STATE_DELETED            = "DELETED"
+	BUILDING_BLOCK_STATUS_WAITING_FOR_DEPENDENT_INPUT  = "WAITING_FOR_DEPENDENT_INPUT"
+	BUILDING_BLOCK_STATUS_WAITING_FOR_OPERATOR_INPUT   = "WAITING_FOR_OPERATOR_INPUT"
+	BUILDING_BLOCK_STATUS_PENDING                      = "PENDING"
+	BUILDING_BLOCK_STATUS_IN_PROGRESS                  = "IN_PROGRESS"
+	BUILDING_BLOCK_STATUS_SUCCEEDED                    = "SUCCEEDED"
+	BUILDING_BLOCK_STATUS_FAILED                       = "FAILED"
+	BUILDING_BLOCK_LIFECYCLE_STATE_ACTIVE              = "ACTIVE"
+	BUILDING_BLOCK_LIFECYCLE_STATE_MARKED_FOR_DELETION = "MARKED_FOR_DELETION"
+	BUILDING_BLOCK_LIFECYCLE_STATE_DELETED             = "DELETED"
 )
 
 type MeshBuildingBlockV2 struct {
@@ -111,6 +113,8 @@ func (bb *MeshBuildingBlockV2) CreateSuccessful() (done bool, err error) {
 func (bb *MeshBuildingBlockV2) DeletionSuccessful() (done bool, err error) {
 	switch {
 	case bb == nil:
+		// Expected when receiving a 404 (hard deletion), default behavior until meshStack v2026.20.0.
+		// For versions higher than that, we get a building block back with a lifecycle state to inspect.
 		done = true
 	case bb.Status.Lifecycle.State == BUILDING_BLOCK_LIFECYCLE_STATE_DELETED:
 		done = true

--- a/docs/data-sources/building_block_v2.md
+++ b/docs/data-sources/building_block_v2.md
@@ -116,7 +116,7 @@ Read-Only:
 
 Read-Only:
 
-- `state` (String) Lifecycle state. `DELETED` indicates the building block has been deleted.
+- `state` (String) Lifecycle state. One of `ACTIVE`, `MARKED_FOR_DELETION`, `DELETED`.
 
 
 <a id="nestedatt--status--outputs"></a>

--- a/docs/data-sources/building_block_v2.md
+++ b/docs/data-sources/building_block_v2.md
@@ -107,8 +107,17 @@ Read-Only:
 Read-Only:
 
 - `force_purge` (Boolean) Indicates whether an operator has requested purging of this Building Block.
+- `lifecycle` (Attributes) Lifecycle state of this building block. (see [below for nested schema](#nestedatt--status--lifecycle))
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
 - `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.
+
+<a id="nestedatt--status--lifecycle"></a>
+### Nested Schema for `status.lifecycle`
+
+Read-Only:
+
+- `state` (String) Lifecycle state. `DELETED` indicates the building block has been deleted.
+
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/docs/resources/building_block_v2.md
+++ b/docs/resources/building_block_v2.md
@@ -168,7 +168,7 @@ Read-Only:
 
 Read-Only:
 
-- `state` (String) Lifecycle state. `DELETED` indicates the building block has been deleted.
+- `state` (String) Lifecycle state. One of `ACTIVE`, `MARKED_FOR_DELETION`, `DELETED`.
 
 
 <a id="nestedatt--status--outputs"></a>

--- a/docs/resources/building_block_v2.md
+++ b/docs/resources/building_block_v2.md
@@ -159,8 +159,17 @@ Read-Only:
 Read-Only:
 
 - `force_purge` (Boolean) Indicates whether an operator has requested purging of this Building Block.
+- `lifecycle` (Attributes) Lifecycle state of this building block. (see [below for nested schema](#nestedatt--status--lifecycle))
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
 - `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.
+
+<a id="nestedatt--status--lifecycle"></a>
+### Nested Schema for `status.lifecycle`
+
+Read-Only:
+
+- `state` (String) Lifecycle state. `DELETED` indicates the building block has been deleted.
+
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/internal/provider/building_block_v2_data_source.go
+++ b/internal/provider/building_block_v2_data_source.go
@@ -134,6 +134,16 @@ func (d *buildingBlockV2DataSource) Schema(ctx context.Context, req datasource.S
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),
+					"lifecycle": schema.SingleNestedAttribute{
+						MarkdownDescription: "Lifecycle state of this building block.",
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"state": schema.StringAttribute{
+								MarkdownDescription: "Lifecycle state. `DELETED` indicates the building block has been deleted.",
+								Computed:            true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -187,6 +197,7 @@ func (d *buildingBlockV2DataSource) Read(ctx context.Context, req datasource.Rea
 	// Set all status values except for outputs
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("status").AtName("status"), bb.Status.Status)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("status").AtName("force_purge"), bb.Status.ForcePurge)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("status").AtName("lifecycle"), bb.Status.Lifecycle)...)
 
 	// Read outputs
 	outputs := make(map[string]buildingBlockOutputModel)

--- a/internal/provider/building_block_v2_data_source.go
+++ b/internal/provider/building_block_v2_data_source.go
@@ -139,8 +139,11 @@ func (d *buildingBlockV2DataSource) Schema(ctx context.Context, req datasource.S
 						Computed:            true,
 						Attributes: map[string]schema.Attribute{
 							"state": schema.StringAttribute{
-								MarkdownDescription: "Lifecycle state. `DELETED` indicates the building block has been deleted.",
-								Computed:            true,
+								MarkdownDescription: fmt.Sprintf("Lifecycle state. One of `%s`, `%s`, `%s`.",
+									client.BUILDING_BLOCK_LIFECYCLE_STATE_ACTIVE,
+									client.BUILDING_BLOCK_LIFECYCLE_STATE_MARKED_FOR_DELETION,
+									client.BUILDING_BLOCK_LIFECYCLE_STATE_DELETED),
+								Computed: true,
 							},
 						},
 					},

--- a/internal/provider/building_block_v2_resource.go
+++ b/internal/provider/building_block_v2_resource.go
@@ -179,8 +179,11 @@ func (r *buildingBlockV2Resource) Schema(ctx context.Context, req resource.Schem
 						Computed:            true,
 						Attributes: map[string]schema.Attribute{
 							"state": schema.StringAttribute{
-								MarkdownDescription: "Lifecycle state. `DELETED` indicates the building block has been deleted.",
-								Computed:            true,
+								MarkdownDescription: fmt.Sprintf("Lifecycle state. One of `%s`, `%s`, `%s`.",
+									client.BUILDING_BLOCK_LIFECYCLE_STATE_ACTIVE,
+									client.BUILDING_BLOCK_LIFECYCLE_STATE_MARKED_FOR_DELETION,
+									client.BUILDING_BLOCK_LIFECYCLE_STATE_DELETED),
+								Computed: true,
 							},
 						},
 					},

--- a/internal/provider/building_block_v2_resource.go
+++ b/internal/provider/building_block_v2_resource.go
@@ -174,6 +174,16 @@ func (r *buildingBlockV2Resource) Schema(ctx context.Context, req resource.Schem
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),
+					"lifecycle": schema.SingleNestedAttribute{
+						MarkdownDescription: "Lifecycle state of this building block.",
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"state": schema.StringAttribute{
+								MarkdownDescription: "Lifecycle state. `DELETED` indicates the building block has been deleted.",
+								Computed:            true,
+							},
+						},
+					},
 				},
 			},
 			"wait_for_completion": schema.BoolAttribute{
@@ -277,7 +287,7 @@ func (r *buildingBlockV2Resource) Read(ctx context.Context, req resource.ReadReq
 		resp.Diagnostics.AddError("Unable to read building block", err.Error())
 	}
 
-	if bb == nil {
+	if bb == nil || bb.Status.Lifecycle.State == client.BUILDING_BLOCK_LIFECYCLE_STATE_DELETED {
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -345,6 +355,8 @@ func setStateFromResponseV2(ctx context.Context, state *tfsdk.State, bb *client.
 	diags.Append(state.SetAttribute(ctx, path.Root("spec").AtName("combined_inputs"), combinedInputs)...)
 
 	diags.Append(state.SetAttribute(ctx, path.Root("status").AtName("status"), bb.Status.Status)...)
+	diags.Append(state.SetAttribute(ctx, path.Root("status").AtName("force_purge"), bb.Status.ForcePurge)...)
+	diags.Append(state.SetAttribute(ctx, path.Root("status").AtName("lifecycle"), bb.Status.Lifecycle)...)
 
 	outputs := make(map[string]buildingBlockOutputModel)
 	for _, output := range bb.Status.Outputs {


### PR DESCRIPTION
- Add MeshBuildingBlockV2Lifecycle struct to capture lifecycle.state from API
- Expose status.lifecycle in resource and data source schemas
- Update DeletionSuccessful() to recognize DELETED lifecycle state as done
- Remove resource from state when lifecycle.state == DELETED
- Fix missing force_purge attribute in resource state assignment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Building blocks now track lifecycle states (ACTIVE, MARKED_FOR_DELETION, DELETED).
  * Lifecycle state is exposed in data sources and resources for visibility.

* **Behavior Changes**
  * Resources with lifecycle DELETED are treated as removed and automatically removed from state.
  * Deletion operations report success when the building block is absent or in DELETED state.

* **Documentation**
  * Docs updated to include the new status.lifecycle/state attribute.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->