### PR TITLE
chore: adapt CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.20.9
+
+BREAKING CHANGES:
+- `meshstack_building_block_v2`: Building blocks in meshStack versions higher than v2026.20.0 are now soft-deleted instead of hard-deleted.
+  The Terraform provider has been updated to correctly detect soft-deleted building blocks by inspecting the 
+  lifecycle state. To ensure correct deletion detection, upgrade the Terraform provider when using meshStack 
+  versions higher than v2026.20.0.
+
+NOTE:
+- This version is backwards-compatible and can be used with older versions of meshStack. If you are using a meshStack version 
+  v2026.20.0 or lower, the provider will continue to work as expected with hard-deleted building blocks.
+
 ## v0.20.8
 
 BREAKING CHANGES:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Building blocks in meshStack v2026.20.0 and later are now soft-deleted instead of hard-deleted; upgrade the Terraform provider to detect soft-deleted building blocks via lifecycle state.

* **Documentation**
  * Release notes updated with a v0.20.9 entry documenting the breaking change, upgrade guidance, and backwards-compatibility note for earlier meshStack versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->