### PR TITLE
chore: add test for BB deletion

### DIFF
--- a/client/buildingblock_v2_test.go
+++ b/client/buildingblock_v2_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMeshBuildingBlockV2_DeletionSuccessful(t *testing.T) {
+	tests := []struct {
+		name     string
+		bb       *MeshBuildingBlockV2
+		wantDone bool
+		wantErr  bool
+	}{
+		{
+			name:     "nil (hard deletion / 404)",
+			bb:       nil,
+			wantDone: true,
+			wantErr:  false,
+		},
+		{
+			name: "lifecycle state DELETED",
+			bb: &MeshBuildingBlockV2{
+				Status: MeshBuildingBlockV2Status{
+					Lifecycle: MeshBuildingBlockV2Lifecycle{State: BUILDING_BLOCK_LIFECYCLE_STATE_DELETED},
+				},
+			},
+			wantDone: true,
+			wantErr:  false,
+		},
+		{
+			name: "status FAILED during deletion",
+			bb: &MeshBuildingBlockV2{
+				Metadata: MeshBuildingBlockV2Metadata{Uuid: "test-uuid"},
+				Status: MeshBuildingBlockV2Status{
+					Status: BUILDING_BLOCK_STATUS_FAILED,
+				},
+			},
+			wantDone: false,
+			wantErr:  true,
+		},
+		{
+			name: "still in progress (MARKED_FOR_DELETION lifecycle, non-failed status)",
+			bb: &MeshBuildingBlockV2{
+				Status: MeshBuildingBlockV2Status{
+					Status:    BUILDING_BLOCK_STATUS_IN_PROGRESS,
+					Lifecycle: MeshBuildingBlockV2Lifecycle{State: BUILDING_BLOCK_LIFECYCLE_STATE_MARKED_FOR_DELETION},
+				},
+			},
+			wantDone: false,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done, err := tt.bb.DeletionSuccessful()
+			assert.Equal(t, tt.wantDone, done)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up on https://github.com/meshcloud/terraform-provider-meshstack/pull/172/changes#r3264364813


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for deletion handling across various scenarios, including successful completions, error states, and in-progress operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->