### PR TITLE
feat: introduce MESHSTACK_SKIP_VERSION_CHECK to skip version check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client/internal"
@@ -66,7 +67,11 @@ func New(ctx context.Context, rootUrl *url.URL, userAgent string, auth Authoriza
 	if meshInfo, err := httpClient.GetMeshInfo(ctx); err != nil {
 		return Client{}, fmt.Errorf("failed to retrieve meshStack version information from /mesh/info endpoint: %w", err)
 	} else if meshInfo.Version.Less(MinMeshStackVersion) {
-		return Client{}, fmt.Errorf("unsupported meshStack version: meshStack is running version %s, but this client requires version %s or higher", meshInfo.Version, MinMeshStackVersion)
+		skipVersionCheck := os.Getenv("MESHSTACK_SKIP_VERSION_CHECK") == "true"
+
+		if !skipVersionCheck {
+			return Client{}, fmt.Errorf("unsupported meshStack version: meshStack is running version %s, but this client requires version %s or higher", meshInfo.Version, MinMeshStackVersion)
+		}
 	}
 
 	return Client{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bypassing meshStack version compatibility checks via an environment variable override. This allows flexibility when working with different meshStack versions while maintaining existing validation by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->