### PR TITLE
chore: adapt CHANGELOG for upcoming release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## v0.20.11
 
 Requires meshStack 2026.22.0 or later (previously 2026.10.0).
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.20.11
  * Updated minimum meshStack version requirement to 2026.22.0
  * Breaking changes: Schema field renames in building block and workspace configurations now require `name` instead of `identifier` attributes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->