### PR TITLE
fix: change input/output structure from array to map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# UNRELEASED
+
+Requires meshStack 2026.23.0 or later (previously 2026.22.0).
+
+BREAKING CHANGES:
+- `meshstack_building_block_v2`: The `spec.inputs` and `status.outputs` fields have changed from arrays to maps in the upstream API.
+  The internal client representation has been updated accordingly. No Terraform schema changes are required, but this requires meshStack 2026.23.0 or later.
+
 ## v0.20.11
 
 Requires meshStack 2026.22.0 or later (previously 2026.10.0).

--- a/client/buildingblock_v2.go
+++ b/client/buildingblock_v2.go
@@ -36,8 +36,22 @@ type MeshBuildingBlockV2Spec struct {
 	TargetRef                         MeshBuildingBlockV2TargetRef            `json:"targetRef" tfsdk:"target_ref"`
 	DisplayName                       string                                  `json:"displayName" tfsdk:"display_name"`
 
-	Inputs               []MeshBuildingBlockIO     `json:"inputs" tfsdk:"inputs"`
-	ParentBuildingBlocks []MeshBuildingBlockParent `json:"parentBuildingBlocks" tfsdk:"parent_building_blocks"`
+	Inputs               map[string]MeshBuildingBlockV2Input `json:"inputs" tfsdk:"-"`
+	ParentBuildingBlocks []MeshBuildingBlockParent           `json:"parentBuildingBlocks" tfsdk:"parent_building_blocks"`
+}
+
+type MeshBuildingBlockV2Input struct {
+	Value                any     `json:"value"`
+	ValueType            string  `json:"valueType"`
+	IsSensitive          bool    `json:"isSensitive"`
+	AssignmentType       *string `json:"assignmentType"`
+	UpdateableByConsumer bool    `json:"updateableByConsumer"`
+}
+
+type MeshBuildingBlockV2Output struct {
+	Value          any     `json:"value"`
+	ValueType      string  `json:"valueType"`
+	AssignmentType *string `json:"assignmentType"`
 }
 
 type MeshBuildingBlockV2DefinitionVersionRef struct {
@@ -59,10 +73,10 @@ type MeshBuildingBlockV2Lifecycle struct {
 }
 
 type MeshBuildingBlockV2Status struct {
-	Status     string                       `json:"status" tfsdk:"status"`
-	Outputs    []MeshBuildingBlockIO        `json:"outputs" tfsdk:"outputs"`
-	ForcePurge bool                         `json:"forcePurge" tfsdk:"force_purge"`
-	Lifecycle  MeshBuildingBlockV2Lifecycle `json:"lifecycle" tfsdk:"lifecycle"`
+	Status     string                               `json:"status" tfsdk:"status"`
+	Outputs    map[string]MeshBuildingBlockV2Output `json:"outputs" tfsdk:"-"`
+	ForcePurge bool                                 `json:"forcePurge" tfsdk:"force_purge"`
+	Lifecycle  MeshBuildingBlockV2Lifecycle         `json:"lifecycle" tfsdk:"lifecycle"`
 }
 
 type MeshBuildingBlockV2Client interface {

--- a/client/client.go
+++ b/client/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/meshcloud/terraform-provider-meshstack/client/version"
 )
 
-var MinMeshStackVersion = version.MustParse("2026.22.0")
+var MinMeshStackVersion = version.MustParse("2026.23.0")
 
 // HttpError represents an HTTP error response with status code.
 // This error is returned when an HTTP request fails with a non-2XX status code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: |-
 
 The meshStack terraform provider is an open-source tool, licensed under the MPL-2.0, and is actively maintained by meshcloud GmbH. The provider exposes APIs of meshStack to manage resources as code.
 
-**Note:** This provider version requires meshStack version 2026.22.0 or higher. The provider automatically validates version compatibility during initialization.
+**Note:** This provider version requires meshStack version 2026.23.0 or higher. The provider automatically validates version compatibility during initialization.
 
 ## Dependency wiring patterns
 

--- a/internal/clientmock/mock_buildingblock_v2.go
+++ b/internal/clientmock/mock_buildingblock_v2.go
@@ -41,7 +41,7 @@ func (m MeshBuildingBlockV2Client) Create(_ context.Context, bb *client.MeshBuil
 		Spec: bb.Spec,
 		Status: client.MeshBuildingBlockV2Status{
 			Status:  client.BUILDING_BLOCK_STATUS_SUCCEEDED,
-			Outputs: make([]client.MeshBuildingBlockIO, 0),
+			Outputs: make(map[string]client.MeshBuildingBlockV2Output),
 		},
 	}
 

--- a/internal/provider/building_block_v2_data_source.go
+++ b/internal/provider/building_block_v2_data_source.go
@@ -189,8 +189,8 @@ func (d *buildingBlockV2DataSource) Read(ctx context.Context, req datasource.Rea
 
 	// Read inputs
 	inputs := make(map[string]buildingBlockIoModel)
-	for _, input := range bb.Spec.Inputs {
-		inputs[input.Key] = toResourceModel(input, &resp.Diagnostics)
+	for key, input := range bb.Spec.Inputs {
+		inputs[key] = toResourceModelV2Input(key, input, &resp.Diagnostics)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -204,8 +204,8 @@ func (d *buildingBlockV2DataSource) Read(ctx context.Context, req datasource.Rea
 
 	// Read outputs
 	outputs := make(map[string]buildingBlockOutputModel)
-	for _, output := range bb.Status.Outputs {
-		outputs[output.Key] = toResourceModel(output, &resp.Diagnostics).toOutputModel()
+	for key, output := range bb.Status.Outputs {
+		outputs[key] = toResourceModelV2Output(key, output, &resp.Diagnostics)
 	}
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/building_block_v2_resource.go
+++ b/internal/provider/building_block_v2_resource.go
@@ -205,7 +205,7 @@ func (r *buildingBlockV2Resource) Create(ctx context.Context, req resource.Creat
 			ParentBuildingBlocks:              make([]client.MeshBuildingBlockParent, 0),
 			BuildingBlockDefinitionVersionRef: client.MeshBuildingBlockV2DefinitionVersionRef{},
 			TargetRef:                         client.MeshBuildingBlockV2TargetRef{},
-			Inputs:                            make([]client.MeshBuildingBlockIO, 0),
+			Inputs:                            make(map[string]client.MeshBuildingBlockV2Input),
 		},
 	}
 
@@ -228,12 +228,11 @@ func (r *buildingBlockV2Resource) Create(ctx context.Context, req resource.Creat
 				fmt.Sprintf("Input '%s' must have one value field set.", key),
 			)
 		}
-		input := client.MeshBuildingBlockIO{
-			Key:       key,
+		input := client.MeshBuildingBlockV2Input{
 			Value:     value,
 			ValueType: valueType,
 		}
-		bb.Spec.Inputs = append(bb.Spec.Inputs, input)
+		bb.Spec.Inputs[key] = input
 	}
 
 	var waitForCompletion bool
@@ -340,6 +339,14 @@ func (r *buildingBlockV2Resource) Delete(ctx context.Context, req resource.Delet
 // 	resource.ImportStatePassthroughID(ctx, path.Root("metadata").AtName("uuid"), req, resp)
 // }
 
+func toResourceModelV2Input(key string, io client.MeshBuildingBlockV2Input, diags *diag.Diagnostics) buildingBlockIoModel {
+	return toResourceModel(client.MeshBuildingBlockIO{Key: key, Value: io.Value, ValueType: io.ValueType}, diags)
+}
+
+func toResourceModelV2Output(key string, io client.MeshBuildingBlockV2Output, diags *diag.Diagnostics) buildingBlockOutputModel {
+	return toResourceModel(client.MeshBuildingBlockIO{Key: key, Value: io.Value, ValueType: io.ValueType}, diags).toOutputModel()
+}
+
 func setStateFromResponseV2(ctx context.Context, state *tfsdk.State, bb *client.MeshBuildingBlockV2) (diags diag.Diagnostics) {
 	diags.Append(state.SetAttribute(ctx, path.Root("metadata"), bb.Metadata)...)
 
@@ -349,8 +356,8 @@ func setStateFromResponseV2(ctx context.Context, state *tfsdk.State, bb *client.
 	diags.Append(state.SetAttribute(ctx, path.Root("spec").AtName("parent_building_blocks"), bb.Spec.ParentBuildingBlocks)...)
 
 	combinedInputs := make(map[string]buildingBlockIoModel)
-	for _, input := range bb.Spec.Inputs {
-		combinedInputs[input.Key] = toResourceModel(input, &diags)
+	for key, input := range bb.Spec.Inputs {
+		combinedInputs[key] = toResourceModelV2Input(key, input, &diags)
 	}
 	if diags.HasError() {
 		return
@@ -362,8 +369,8 @@ func setStateFromResponseV2(ctx context.Context, state *tfsdk.State, bb *client.
 	diags.Append(state.SetAttribute(ctx, path.Root("status").AtName("lifecycle"), bb.Status.Lifecycle)...)
 
 	outputs := make(map[string]buildingBlockOutputModel)
-	for _, output := range bb.Status.Outputs {
-		outputs[output.Key] = toResourceModel(output, &diags).toOutputModel()
+	for key, output := range bb.Status.Outputs {
+		outputs[key] = toResourceModelV2Output(key, output, &diags)
 	}
 	if diags.HasError() {
 		return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Building block inputs and outputs now use named keys instead of indexed lists for clearer configuration and state mapping.

* **Chore**
  * Minimum required meshStack version raised to 2026.23.0.

* **Documentation**
  * Docs and changelog updated to reflect the new minimum meshStack version and the inputs/outputs shape change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meshcloud/terraform-provider-meshstack/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->