### PR TITLE
feat: add ALL capability to building block runner implementation types

### DIFF
--- a/client/buildingblock_runner.go
+++ b/client/buildingblock_runner.go
@@ -15,6 +15,7 @@ const (
 	MeshBuildingBlockRunnerImplementationTypeGitlabPipeline      MeshBuildingBlockRunnerImplementationType = "GITLAB_PIPELINE"
 	MeshBuildingBlockRunnerImplementationTypeAzureDevopsPipeline MeshBuildingBlockRunnerImplementationType = "AZURE_DEVOPS_PIPELINE"
 	MeshBuildingBlockRunnerImplementationTypeManual              MeshBuildingBlockRunnerImplementationType = "MANUAL"
+	MeshBuildingBlockRunnerImplementationTypeAll                 MeshBuildingBlockRunnerImplementationType = "ALL"
 )
 
 var MeshBuildingBlockRunnerImplementationTypes = []string{
@@ -23,6 +24,7 @@ var MeshBuildingBlockRunnerImplementationTypes = []string{
 	string(MeshBuildingBlockRunnerImplementationTypeGitlabPipeline),
 	string(MeshBuildingBlockRunnerImplementationTypeAzureDevopsPipeline),
 	string(MeshBuildingBlockRunnerImplementationTypeManual),
+	string(MeshBuildingBlockRunnerImplementationTypeAll),
 }
 
 type BuildingBlockRunnerRef struct {

--- a/docs/resources/building_block_runner.md
+++ b/docs/resources/building_block_runner.md
@@ -87,7 +87,7 @@ Read-Only:
 Required:
 
 - `display_name` (String) Human-readable display name of the runner.
-- `implementation_type` (String) Type of building block implementation this runner handles. One of: `TERRAFORM`, `GITHUB_WORKFLOW`, `GITLAB_PIPELINE`, `AZURE_DEVOPS_PIPELINE`, `MANUAL`.
+- `implementation_type` (String) Type of building block implementation this runner handles. One of: `TERRAFORM`, `GITHUB_WORKFLOW`, `GITLAB_PIPELINE`, `AZURE_DEVOPS_PIPELINE`, `MANUAL`, `ALL`. Use `ALL` to handle building blocks of any implementation type.
 - `public_key` (String) RSA public key in PEM format (`BEGIN PUBLIC KEY`) or an X.509 certificate (`BEGIN CERTIFICATE`). meshStack uses this key to encrypt secrets sent to the runner.
 
 Optional:

--- a/internal/provider/building_block_runner_resource.go
+++ b/internal/provider/building_block_runner_resource.go
@@ -158,7 +158,7 @@ func (r *buildingBlockRunnerResource) Schema(_ context.Context, _ resource.Schem
 						Required:            true,
 					},
 					"implementation_type": schema.StringAttribute{
-						MarkdownDescription: "Type of building block implementation this runner handles. One of: `TERRAFORM`, `GITHUB_WORKFLOW`, `GITLAB_PIPELINE`, `AZURE_DEVOPS_PIPELINE`, `MANUAL`.",
+						MarkdownDescription: "Type of building block implementation this runner handles. One of: `TERRAFORM`, `GITHUB_WORKFLOW`, `GITLAB_PIPELINE`, `AZURE_DEVOPS_PIPELINE`, `MANUAL`, `ALL`. Use `ALL` to handle building blocks of any implementation type.",
 						Required:            true,
 						PlanModifiers: []planmodifier.String{
 							// TODO: Switch to in-place update once meshStack supports updating implementation type.


### PR DESCRIPTION
The meshStack backend now models runner capabilities and building block types as separate enums, with runners gaining an additional ALL value that allows a single runner to handle building blocks of any implementation type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `ALL` implementation type option for building block runners, enabling them to handle building blocks of any implementation type.

* **Documentation**
  * Updated schema documentation to clarify the `ALL` implementation type option behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->