### PR TITLE
fix: use new one-for-all-implementation shared runner UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.21.1
+
+FIXES:
+- When no `runner_ref` is provided, the new shared building block runner UUID `98520496-627d-43e6-82da-ce499179ff3f` is used which is suitable for all implementation types.
+  Existing `building_block_definition` resources will see a plan change addressing this migration to a single shared runner. 
+  Using the old shared runner UUIDs is deprecated but handled gracefully by the API.
+
 # v0.21.0
 
 Requires meshStack 2026.23.0 or later (previously 2026.22.0).

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -46,7 +46,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
     # Optional: Specify runner if necessary (otherwise, shared runner is used)
     runner_ref = {
       kind = "meshBuildingBlockRunner"
-      uuid = "66ddc814-1e69-4dad-b5f1-3a5bce51c01f"
+      uuid = "98520496-627d-43e6-82da-ce499179ff3f"
     }
 
     only_apply_once_per_tenant = true     # Optional: defaults to false

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -26,7 +26,7 @@ resource "meshstack_integration" "example_github" {
         base_url        = "https://github.com"
         app_id          = "123456"
         app_private_key = { secret_value = "-----BEGIN RSA PRIVATE KEY-----\nMOCK_KEY_CONTENT\n-----END RSA PRIVATE KEY-----" }
-        runner_ref      = { uuid = "dc8c57a1-823f-4e96-8582-0275fa27dc7b" } # Optional, by default, pre-defined shared runner is used
+        runner_ref      = { uuid = "98520496-627d-43e6-82da-ce499179ff3f" } # Optional, by default, pre-defined shared runner is used
       }
     }
   }

--- a/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
+++ b/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
@@ -28,7 +28,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
     # Optional: Specify runner if necessary (otherwise, shared runner is used)
     runner_ref = {
       kind = "meshBuildingBlockRunner"
-      uuid = "66ddc814-1e69-4dad-b5f1-3a5bce51c01f"
+      uuid = "98520496-627d-43e6-82da-ce499179ff3f"
     }
 
     only_apply_once_per_tenant = true     # Optional: defaults to false

--- a/examples/resources/meshstack_integration/resource_01_github.tf
+++ b/examples/resources/meshstack_integration/resource_01_github.tf
@@ -11,7 +11,7 @@ resource "meshstack_integration" "example_github" {
         base_url        = "https://github.com"
         app_id          = "123456"
         app_private_key = { secret_value = "-----BEGIN RSA PRIVATE KEY-----\nMOCK_KEY_CONTENT\n-----END RSA PRIVATE KEY-----" }
-        runner_ref      = { uuid = "dc8c57a1-823f-4e96-8582-0275fa27dc7b" } # Optional, by default, pre-defined shared runner is used
+        runner_ref      = { uuid = "98520496-627d-43e6-82da-ce499179ff3f" } # Optional, by default, pre-defined shared runner is used
       }
     }
   }

--- a/internal/provider/building_block_definition_resource_model.go
+++ b/internal/provider/building_block_definition_resource_model.go
@@ -70,8 +70,10 @@ func (model buildingBlockDefinitionVersionSpec) ToClientDto(buildingBlockDefinit
 		Uuid: buildingBlockDefinitionUuid,
 	}
 	if dto.RunnerRef == nil {
-		implementationType := dto.Implementation.InferTypeFromNonNilField()
-		dto.RunnerRef = getSharedBuildingBlockRunnerRef(implementationType)
+		dto.RunnerRef = &client.BuildingBlockRunnerRef{
+			Kind: client.MeshObjectKind.BuildingBlockRunner,
+			Uuid: SharedBuildingBlockRunnerUuid,
+		}
 	}
 	if model.Draft {
 		dto.State = client.MeshBuildingBlockDefinitionVersionStateDraft.Ptr()

--- a/internal/provider/building_block_definition_resource_test.go
+++ b/internal/provider/building_block_definition_resource_test.go
@@ -420,14 +420,6 @@ func checkBBDSpecMinimal(expectedDescription string) knownvalue.Check {
 }
 
 func checkBuildingBlockVersionSpec(exampleSuffix string, expectedState enum.Entry[client.MeshBuildingBlockDefinitionVersionState], expectedNumber int64) knownvalue.Check {
-	exampleSuffixesToImplementationType := map[string]enum.Entry[client.MeshBuildingBlockImplementationType]{
-		"01_terraform":             client.MeshBuildingBlockImplementationTypeTerraform,
-		"02_github_workflows":      client.MeshBuildingBlockImplementationTypeGithubWorkflows,
-		"03_manual":                client.MeshBuildingBlockImplementationTypeManual,
-		"04_azure_devops_pipeline": client.MeshBuildingBlockImplementationTypeAzureDevOpsPipeline,
-		"05_gitlab_pipeline":       client.MeshBuildingBlockImplementationTypeGitlabPipeline,
-	}
-
 	checkInputs, checkImplementation, checkOutputs := checksForImplementation(exampleSuffix)
 	expectedDeletionMode := "DELETE"
 	if exampleSuffix == "02_github_workflows" {
@@ -441,7 +433,7 @@ func checkBuildingBlockVersionSpec(exampleSuffix string, expectedState enum.Entr
 		"deletion_mode":              knownvalue.StringExact(expectedDeletionMode),
 		"runner_ref": xknownvalue.MapExact(map[string]knownvalue.Check{
 			"kind": knownvalue.StringExact("meshBuildingBlockRunner"),
-			"uuid": knownvalue.StringExact(SharedBuildingBlockRunnerUuids[exampleSuffixesToImplementationType[exampleSuffix]]),
+			"uuid": knownvalue.StringExact(SharedBuildingBlockRunnerUuid),
 		}),
 		"dependency_refs": knownvalue.SetSizeExact(0),
 		"inputs":          checkInputs,

--- a/internal/provider/building_block_runner.go
+++ b/internal/provider/building_block_runner.go
@@ -1,23 +1,3 @@
 package provider
 
-import (
-	"github.com/meshcloud/terraform-provider-meshstack/client"
-	"github.com/meshcloud/terraform-provider-meshstack/client/types/enum"
-)
-
-var (
-	SharedBuildingBlockRunnerUuids = map[enum.Entry[client.MeshBuildingBlockImplementationType]]string{
-		client.MeshBuildingBlockImplementationTypeManual:              "46b7c17a-61f0-4062-9601-5785e60ce11f",
-		client.MeshBuildingBlockImplementationTypeTerraform:           "66ddc814-1e69-4dad-b5f1-3a5bce51c01f",
-		client.MeshBuildingBlockImplementationTypeGithubWorkflows:     "dc8c57a1-823f-4e96-8582-0275fa27dc7b",
-		client.MeshBuildingBlockImplementationTypeGitlabPipeline:      "f4f4402b-f54d-4ab9-93ae-c07e997041e9",
-		client.MeshBuildingBlockImplementationTypeAzureDevOpsPipeline: "05cfa85f-2818-4bdd-b193-620e0187d7de",
-	}
-)
-
-func getSharedBuildingBlockRunnerRef(implementationType enum.Entry[client.MeshBuildingBlockImplementationType]) *client.BuildingBlockRunnerRef {
-	return &client.BuildingBlockRunnerRef{
-		Kind: client.MeshObjectKind.BuildingBlockRunner,
-		Uuid: SharedBuildingBlockRunnerUuids[implementationType],
-	}
-}
+const SharedBuildingBlockRunnerUuid = "98520496-627d-43e6-82da-ce499179ff3f"

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
-	"github.com/meshcloud/terraform-provider-meshstack/client/types/enum"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/generic"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/secret"
 )
@@ -47,25 +46,22 @@ type integrationModel struct {
 	} `tfsdk:"ref"`
 }
 
-var IntegrationConfigTypeToBBDImplType = map[enum.Entry[client.MeshIntegrationConfigType]]enum.Entry[client.MeshBuildingBlockImplementationType]{
-	client.MeshIntegrationConfigTypeGithub:      client.MeshBuildingBlockImplementationTypeGithubWorkflows,
-	client.MeshIntegrationConfigTypeGitlab:      client.MeshBuildingBlockImplementationTypeGitlabPipeline,
-	client.MeshIntegrationConfigTypeAzureDevops: client.MeshBuildingBlockImplementationTypeAzureDevOpsPipeline,
-}
-
 func (model integrationModel) ToClientDto() client.MeshIntegration {
-	setRunnerRefIfNotNil := func(configType enum.Entry[client.MeshIntegrationConfigType], runnerRef **client.BuildingBlockRunnerRef) {
+	setRunnerRefIfNil := func(runnerRef **client.BuildingBlockRunnerRef) {
 		if *runnerRef == nil {
-			*runnerRef = getSharedBuildingBlockRunnerRef(IntegrationConfigTypeToBBDImplType[configType])
+			*runnerRef = &client.BuildingBlockRunnerRef{
+				Kind: client.MeshObjectKind.BuildingBlockRunner,
+				Uuid: SharedBuildingBlockRunnerUuid,
+			}
 		}
 	}
-	switch configType := model.Spec.Config.InferTypeFromNonNilField(); configType {
+	switch model.Spec.Config.InferTypeFromNonNilField() {
 	case client.MeshIntegrationConfigTypeGithub:
-		setRunnerRefIfNotNil(configType, &model.Spec.Config.Github.RunnerRef)
+		setRunnerRefIfNil(&model.Spec.Config.Github.RunnerRef)
 	case client.MeshIntegrationConfigTypeGitlab:
-		setRunnerRefIfNotNil(configType, &model.Spec.Config.Gitlab.RunnerRef)
+		setRunnerRefIfNil(&model.Spec.Config.Gitlab.RunnerRef)
 	case client.MeshIntegrationConfigTypeAzureDevops:
-		setRunnerRefIfNotNil(configType, &model.Spec.Config.AzureDevops.RunnerRef)
+		setRunnerRefIfNil(&model.Spec.Config.AzureDevops.RunnerRef)
 	}
 	return model.MeshIntegration
 }

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -210,7 +210,7 @@ func checkIntegrationConfig(exampleSuffix string) knownvalue.Check {
 					"secret_version": xknownvalue.NotEmptyString(),
 				}),
 				"runner_ref": xknownvalue.MapExact(map[string]knownvalue.Check{
-					"uuid": knownvalue.StringExact("dc8c57a1-823f-4e96-8582-0275fa27dc7b"),
+					"uuid": knownvalue.StringExact(SharedBuildingBlockRunnerUuid),
 					"kind": knownvalue.StringExact("meshBuildingBlockRunner"),
 				}),
 			}),
@@ -229,7 +229,7 @@ func checkIntegrationConfig(exampleSuffix string) knownvalue.Check {
 					"secret_version": xknownvalue.NotEmptyString(),
 				}),
 				"runner_ref": xknownvalue.MapExact(map[string]knownvalue.Check{
-					"uuid": knownvalue.StringExact("05cfa85f-2818-4bdd-b193-620e0187d7de"),
+					"uuid": knownvalue.StringExact(SharedBuildingBlockRunnerUuid),
 					"kind": knownvalue.StringExact("meshBuildingBlockRunner"),
 				}),
 			}),
@@ -242,7 +242,7 @@ func checkIntegrationConfig(exampleSuffix string) knownvalue.Check {
 			"gitlab": xknownvalue.MapExact(map[string]knownvalue.Check{
 				"base_url": knownvalue.StringExact("https://gitlab.com"),
 				"runner_ref": xknownvalue.MapExact(map[string]knownvalue.Check{
-					"uuid": knownvalue.StringExact("f4f4402b-f54d-4ab9-93ae-c07e997041e9"),
+					"uuid": knownvalue.StringExact(SharedBuildingBlockRunnerUuid),
 					"kind": knownvalue.StringExact("meshBuildingBlockRunner"),
 				}),
 			}),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runner reference management now uses a single shared UUID; existing building block definitions will show a plan change during migration
  * Deprecated old shared runner UUIDs are handled gracefully by the API

* **Documentation**
  * Updated documentation and examples with the new unified runner reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->