### PR TITLE
ci: dockerized acceptance test workflow

### DIFF
--- a/.agents/skills/meshstack-services/SKILL.md
+++ b/.agents/skills/meshstack-services/SKILL.md
@@ -1,98 +1,48 @@
 ---
 name: meshstack-services
-description: Bring up a clean local meshStack backend for acceptance testing — hard-restart the meshfed-release infrastructure (docker compose), start the three meshfed-release Gradle services (meshfed-api, block-coordinator, replicator) plus the manual block runner from the separate building-block-runner repo, and verify readiness via logs. Use before running acceptance tests, or when the backend is down / returning stale-data 409s. (The skill is named meshstack-services; the backend repo keeps its legacy name "meshfed-release".)
+description: Bring up a clean local meshStack backend for acceptance testing. The backend (docker compose infra + the three meshfed-release Gradle services) is brought up via the meshfed-release `local-dev-stack` skill; this skill adds only the acceptance-test-specific part — run a single manual block runner so terraform-implementation BBDs are no-op'd. Use before running acceptance tests, or when the backend is down / returning stale-data 409s.
 ---
 
 # meshStack backend (meshfed-release) for acceptance testing
 
-Stand up a clean meshStack backend suitable for acceptance testing. Most of it lives in the
-`meshfed-release` repo (may sit relatively at `../meshfed-release`); the manual block runner has
-been extracted into a separate `building-block-runner` repo (may sit at `../building-block-runner`).
-Do not assume absolute paths. Unless noted otherwise, run infrastructure and meshfed-release
-service commands from the `meshfed-release/` directory.
+The backend lives in the **`meshfed-release`** repo (may sit at `../meshfed-release`). Hard-restarting
+the docker compose infrastructure and starting the three meshfed services (meshfed-api,
+block-coordinator, replicator) — with readiness markers and startup pitfalls — is the
+**`local-dev-stack`** skill in that repo. Follow its infra + services steps, then return here for the
+acceptance-test runner.
 
-> If services are already running on another worktree's code, do **not** restart them — that
-> would disrupt an in-progress session.
+> If services are already running on another worktree's code, do **not** restart them.
 
-## 1. Hard restart infrastructure
+## Runner: a single manual block runner (acceptance topology)
 
-```bash
-cd meshfed-release/
-docker compose down && docker compose up -d
-```
-
-- **Volumes:** only keycloak is named/persistent. mariadb & ravendb are ephemeral → recreated
-  clean on `down`+`up`. A clean DB avoids stale-data `409` conflicts from previous runs.
-  mariadb re-seeds via `./ci/backend/container/initdb.d`.
-- **Wait for readiness, bounded** — don't block indefinitely:
-  - ravendb: healthcheck reports `healthy`
-  - mariadb: log shows `ready for connections` / init process done
-
-## 2. Start the services in the background
-
-The `:*:start` / `:*:bootRun` Gradle tasks run Spring Boot apps and **block forever** — never
-await them. Use `nohup … &` and verify readiness via the logs.
-
-### 2a. Three meshfed-release services (from `meshfed-release/`)
+The acceptance suite needs the **manual** runner to claim **all** runs and no-op them — it echoes
+inputs as outputs for *both* manual and terraform-implementation BBDs, so the suite never executes
+real OpenTofu. Run **only** the manual runner, polling meshfed directly as the shared runner UUID —
+**not** the multiplexer fan-out from `local-dev-stack`, which routes terraform-implementation BBDs to
+the real `tf-block-runner` (that would actually run tofu).
 
 ```bash
-: > /tmp/meshstack-api.log; : > /tmp/block-coordinator.log; : > /tmp/replicator.log
-nohup ./gradlew :meshfed:meshfed-api:start --console=plain > /tmp/meshstack-api.log 2>&1 &
-nohup ./gradlew :buildingblocks:block-coordinator-api:start --console=plain > /tmp/block-coordinator.log 2>&1 &
-nohup ./gradlew :meshfed:replicator:replicator-api:start --console=plain > /tmp/replicator.log 2>&1 &
-```
-
-### 2b. Manual block runner (from the `building-block-runner` repo)
-
-The manual block runner has been **moved out of `meshfed-release`** into the separate
-`building-block-runner` repo (it may sit relatively at `../building-block-runner`); the old
-`meshfed-release` `:buildingblocks:manual-block-runner:start` task no longer exists. Start the
-runner from the `building-block-runner` repo.
-
-```bash
-cd ../building-block-runner   # extracted from meshfed-release
+cd ../building-block-runner    # the runner was extracted out of meshfed-release
 : > /tmp/manual-runner.log
 RUNNER_UUID=98520496-627d-43e6-82da-ce499179ff3f \
+  RUNNER_API_CLIENT_ID=<local managed-runners client id> \
+  RUNNER_API_CLIENT_SECRET=<local managed-runners secret> \
   nohup ./gradlew :manual-block-runner:bootRun --console=plain > /tmp/manual-runner.log 2>&1 &
 ```
 
-- **`RUNNER_UUID` is critical.** The runner only picks up runs assigned to its own UUID. It
-  **must** equal the provider's `SharedBuildingBlockRunnerUuid`
-  (`98520496-627d-43e6-82da-ce499179ff3f`, see `internal/provider/building_block_runner.go`),
-  which all manual BBD examples/tests default to. The repo's built-in default
-  (`46b7c17a-…`) does **not** match — using it leaves manual building blocks stuck at `PENDING`.
-- Other config defaults are fine locally: it polls `RUNNER_API_URL` (default
-  `http://localhost:8080`) every ~10s with basic auth `RUNNER_API_USERNAME`/`RUNNER_API_PASSWORD`
-  (default `bb-api`/`guest`). Override via env or a `runner-config.yml` only if your local
-  setup differs.
+- **`RUNNER_UUID` is critical** — it must equal the provider's `SharedBuildingBlockRunnerUuid`
+  (`98520496-627d-43e6-82da-ce499179ff3f`, see `internal/provider/building_block_runner.go`), which
+  all BBD examples/tests default to. The runner's built-in default (`46b7c17a-…`) does **not** match
+  and leaves building blocks stuck at `PENDING`.
+- **Auth: prefer the API key.** Authenticate with the local managed-runners API key via
+  `RUNNER_API_CLIENT_ID` / `RUNNER_API_CLIENT_SECRET`. The seeded local dev values are in the
+  meshfed-release `local-dev-stack` skill (kept out of this public repo). The legacy basic auth
+  `RUNNER_API_USERNAME` / `RUNNER_API_PASSWORD` still works as a deprecated fallback, but the API key
+  takes precedence when both are set.
 
-> The **manual** runner is what acceptance testing uses — it no-ops both manual and
-> terraform-implementation BBDs (echoes inputs as outputs). Keep it for the acceptance suite.
-> To instead run a *terraform-implementation* BBD end-to-end in `scratch/` (real `git clone` +
-> OpenTofu) — only for ad-hoc play, never the acceptance suite — swap this manual runner for the
-> `tf-block-runner`; see the optional section in the **`scratch-config-testing`** skill.
-
-**Readiness markers** (grep the logs; ~60–120s on first build):
-
-| Service           | Log file                    | Marker                                     | Port |
-|-------------------|-----------------------------|--------------------------------------------|------|
-| meshfed-api       | `/tmp/meshstack-api.log`    | `Started ApplicationKt`                    | 8080 |
-| block-coordinator | `/tmp/block-coordinator.log`| `Started BlockCoordinatorApiApplicationKt` | 8083 |
-| replicator        | `/tmp/replicator.log`       | `Started ApplicationKt`                     | —    |
-| manual-runner     | `/tmp/manual-runner.log`    | `Started BlockRunnerApplication`           | — (no HTTP; polls every ~10s) |
-
-Watch for `BUILD FAILED` / exceptions in the logs rather than waiting for a timeout.
-
-### Startup pitfalls
-
-- **Corrupted Kotlin incremental cache** fails meshfed-api with `Storage corrupted …/lookups.tab_i`,
-  cascading to `Unresolved reference 'meshobjects'`. Fix and restart that service:
-  ```bash
-  rm -rf core/meshobjects/build/kotlin core/rest/build/kotlin
-  ```
-- Transient okhttp errors in `manual-runner.log` during startup-before-infra-ready are benign.
+Ready marker: `Started BlockRunnerApplication` in `/tmp/manual-runner.log` (no HTTP port; polls ~10s).
 
 ## Next
 
-Once all four services (three meshfed-release + the manual runner) report ready, run the
-suite — see the **`acceptance-testing`** skill.
+Backend (per `local-dev-stack`) + this manual runner ready → run the suite (see the
+**`acceptance-testing`** skill).

--- a/.agents/skills/scratch-config-testing/SKILL.md
+++ b/.agents/skills/scratch-config-testing/SKILL.md
@@ -96,13 +96,18 @@ the **`tf-block-runner`** — a Go app in the `building-block-runner` repo (may 
 pkill -9 -f "BlockRunnerApplicationKt"          # stop the manual runner (same UUID would race)
 cd ../building-block-runner/tf-block-runner
 RUNNER_UUID=98520496-627d-43e6-82da-ce499179ff3f \
+  RUNNER_API_CLIENT_ID=<local managed-runners client id> \
+  RUNNER_API_CLIENT_SECRET=<local managed-runners secret> \
   nohup go run . > /tmp/tf-runner.log 2>&1 &     # restart the manual runner afterwards for acc tests
 ```
 
 `RUNNER_UUID` (env) overrides `runner-config.yml` and **must** equal the
 `SharedBuildingBlockRunnerUuid` (`internal/provider/building_block_runner.go`,
-`98520496-…`) that BBD examples default to, or runs sit unclaimed. The runner polls
-`localhost:8080` (bb-api/guest), downloads OpenTofu via tofudl, clones the BBD's
+`98520496-…`) that BBD examples default to, or runs sit unclaimed. It authenticates with the local
+managed-runners API key (`RUNNER_API_CLIENT_ID`/`RUNNER_API_CLIENT_SECRET` above — seeded dev values
+are in the meshfed-release `local-dev-stack` skill, kept out of this public repo; the tf-block-runner
+no longer ships a basic-auth default). The runner polls `localhost:8080`, downloads OpenTofu via
+tofudl, clones the BBD's
 `repository_url`, and for a module that declares no backend injects the mesh http backend
 (`use_mesh_http_backend_fallback = true`). Watch `/tmp/tf-runner.log`; the building block
 reaches `SUCCEEDED` with real tofu outputs in TF state. A minimal BBD `implementation`:

--- a/.github/scripts/coverage-comment.sh
+++ b/.github/scripts/coverage-comment.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Render/update the single coverage comment on a pull request (matched by an HTML marker so both
+# CI jobs target the same comment). Used by .github/workflows/test.yml in two stages:
+#
+#   coverage-comment.sh unit       (Go Test job)      post unit coverage; combined row pending
+#   coverage-comment.sh combined   (Acceptance job)   merge unit + acceptance coverage and rewrite
+#
+# Coverage is read from binary coverage-data directories (GOCOVERDIR format) so unit and acceptance
+# data — produced on different runners and carried between them as an artifact — can be merged with
+# `go tool covdata merge`. Expected layout (relative to the repo checkout / working dir):
+#
+#   covdata/unit   unit (mock client) coverage data
+#   covdata/acc    acceptance coverage data (combined stage only)
+#
+# Required env: REPO (owner/name), PR (pull request number), GH_TOKEN (for gh). Must run from the
+# module root so `go tool cover -func` can resolve package paths. Safe to run when no coverage data
+# was produced (e.g. tests failed before flushing) — it reports "n/a" rather than erroring.
+set -euo pipefail
+
+MODE="${1:?usage: coverage-comment.sh <unit|combined>}"
+MARKER='<!-- coverage-report -->'
+
+# True when a coverage-data dir actually contains data.
+have_data() { ls "$1"/covmeta.* >/dev/null 2>&1; }
+
+# total_percent <text-profile> -> total coverage percentage (e.g. "56.3%").
+total_percent() { go tool cover -func="$1" | tail -1 | awk '{print $NF}'; }
+
+# Up to 10 zero-coverage functions from a text profile. awk caps the output itself (instead of
+# `| head -10`) so it never receives SIGPIPE from an early-closing reader — under `set -o pipefail`
+# that would otherwise fail the step with exit 141.
+top_uncovered() { awk '$3 == "0.0%" { print; if (++n == 10) exit }' "$1"; }
+
+# Unit figure (shown in both stages); computed from the unit data dir when present.
+UNIT_CELL='`n/a`'
+if have_data covdata/unit; then
+  go tool covdata textfmt -i=covdata/unit -o=unit.txt
+  UNIT_CELL="\`$(total_percent unit.txt)\`"
+fi
+
+case "$MODE" in
+  unit)
+    COMBINED_CELL='⏳ acceptance job running…'
+    if have_data covdata/unit; then
+      UNCOVERED=$(top_uncovered unit.txt)
+    else
+      UNIT_CELL='`n/a (no coverage produced)`'
+      UNCOVERED=""
+    fi
+    DETAILS="Uncovered functions (unit run)"
+    NOTE="_Coverage is collected across all packages (\`-coverpkg=./...\`). The combined figure is filled in once the acceptance job finishes._"
+    ;;
+  combined)
+    # Merge whichever coverage-data dirs actually have data.
+    inputs=""
+    have_data covdata/unit && inputs="covdata/unit"
+    have_data covdata/acc && inputs="${inputs:+$inputs,}covdata/acc"
+    if [ -n "$inputs" ]; then
+      mkdir -p covdata/merged
+      go tool covdata merge -i="$inputs" -o=covdata/merged
+      go tool covdata textfmt -i=covdata/merged -o=merged.txt
+      go tool cover -func=merged.txt > merged-summary.txt
+      COMBINED_CELL="\`$(total_percent merged.txt)\`"
+      UNCOVERED=$(top_uncovered merged-summary.txt)
+    else
+      COMBINED_CELL='`n/a (no coverage produced)`'
+      UNCOVERED=""
+    fi
+    DETAILS="Uncovered functions (combined run)"
+    NOTE="_Combined with \`go tool covdata merge\` over the unit and acceptance coverage data. The acceptance suite runs \`./internal/provider\` against the live backend; coverage is attributed across all packages (\`-coverpkg=./...\`)._"
+    ;;
+  *)
+    echo "unknown mode: $MODE (expected 'unit' or 'combined')" >&2
+    exit 2
+    ;;
+esac
+
+[ -n "$UNCOVERED" ] || UNCOVERED="(none — every function has some coverage)"
+
+# Acceptance status annotation for the combined row (combined stage only). The workflow passes in
+# ACC_COMPLETE (did the run reach gotestsum's summary?) and ACC_OUTCOME (pass/fail). An incomplete
+# run is a self-hosted-runner truncation — its result is unknown, so it must never read as a pass.
+ACC_TAG=""
+ACC_NOTE=""
+if [ "$MODE" = combined ]; then
+  case "${ACC_COMPLETE:-}" in
+    false)
+      ACC_TAG=" — 🛑 acceptance incomplete"
+      ACC_NOTE="🛑 **The acceptance run did not complete** (the self-hosted runner truncated or killed it before gotestsum reported a summary). The combined figure above therefore omits acceptance and the acceptance result is **unknown — not a pass**; re-run the job."
+      ;;
+    true)
+      case "${ACC_OUTCOME:-}" in
+        success) ACC_TAG=" — ✅ acceptance passed" ;;
+        failure)
+          ACC_TAG=" — ❌ acceptance failed"
+          ACC_NOTE="❌ **Acceptance tests failed** (advisory — the job runs against the last *merged* meshfed-release backend, so a change needing a companion backend PR fails here until that backend merges; the real gate is meshfed-release's \`terraform-provider-acceptance\` job)."
+          ;;
+      esac
+      ;;
+  esac
+fi
+
+{
+  echo "$MARKER"
+  echo "## 📊 Test Coverage"
+  echo ""
+  echo "| Scope | Coverage |"
+  echo "| --- | --- |"
+  echo "| Unit tests (mock client) | ${UNIT_CELL} |"
+  echo "| Combined (unit + acceptance) | ${COMBINED_CELL}${ACC_TAG} |"
+  echo ""
+  [ -z "$ACC_NOTE" ] || { echo "$ACC_NOTE"; echo ""; }
+  echo "<details><summary>${DETAILS}</summary>"
+  echo ""
+  echo '```'
+  echo "$UNCOVERED"
+  echo '```'
+  echo "</details>"
+  echo ""
+  echo "$NOTE"
+} > coverage.md
+
+[ -z "${GITHUB_STEP_SUMMARY:-}" ] || cat coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+# Rewrite the marked comment if it exists, otherwise create it.
+cid=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+  --jq "[.[] | select(.body | contains(\"$MARKER\"))] | last | .id" 2>/dev/null || true)
+if [ -n "$cid" ] && [ "$cid" != "null" ]; then
+  gh api -X PATCH "repos/$REPO/issues/comments/$cid" -F body=@coverage.md >/dev/null
+  echo "updated coverage comment #$cid ($MODE)"
+else
+  gh pr comment "$PR" --body-file coverage.md
+  echo "created coverage comment ($MODE)"
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same ref (the acceptance job is expensive).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Go Build
@@ -90,44 +95,317 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - name: Run tests with gotestsum
-        run: go tool gotestsum --junitfile junit.xml --format testdox -- -coverprofile=coverage.out -coverpkg=./... ./...
-      - name: Generate coverage report
-        if: always()
+      # Emit coverage as a binary coverage-data directory (GOCOVERDIR format) rather than a text
+      # profile, so the acceptance job on a different runner can merge it with its own live-backend
+      # coverage via `go tool covdata merge`. `-coverpkg=./...` attributes coverage across all
+      # packages; the test binaries flush coverage on exit even when a test fails.
+      - name: Run unit tests with gotestsum
         run: |
-          # Generate detailed coverage
-          go tool cover -func=coverage.out > coverage-summary.txt
-          TOTAL=$(tail -1 coverage-summary.txt | awk '{print $3}')
-          
-          # Job summary
-          echo "## Test Coverage: $TOTAL" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "<details><summary>Coverage by file</summary>" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          head -50 coverage-summary.txt >> $GITHUB_STEP_SUMMARY
-          echo '...' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "</details>" >> $GITHUB_STEP_SUMMARY
-      - name: Post coverage to PR
-        if: github.event_name == 'pull_request'
+          mkdir -p covdata/unit
+          go tool gotestsum --junitfile junit.xml --format testdox -- \
+            -coverpkg=./... ./... -args -test.gocoverdir="$PWD/covdata/unit"
+
+      # Hand the unit coverage data to the acceptance job (a separate, self-hosted runner). Always
+      # upload, even on test failure, so the combined report can still be produced.
+      - name: Upload unit coverage data
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: covdata-unit
+          path: covdata/unit
+          retention-days: 1
+          if-no-files-found: warn
+
+      # Post (or refresh) the single coverage comment with the unit figure and a placeholder for the
+      # combined number. The acceptance job rewrites this same comment (matched by the HTML marker)
+      # once it has merged in the live-backend coverage.
+      - name: Post coverage to PR (unit; acceptance pending)
+        if: ${{ always() && github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          TOTAL=$(tail -1 coverage-summary.txt | awk '{print $3}')
-          
-          # Create comment body
-          COMMENT="## 📊 Test Coverage: $TOTAL
-          
-          <details><summary>Top uncovered files</summary>
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: .github/scripts/coverage-comment.sh unit
 
-          \`\`\`
-          $(grep '0.0%' coverage-summary.txt | head -10 || echo 'All files have some coverage!')
-          \`\`\`
-          </details>
-          
-          *Coverage measured across all packages with \`-coverpkg=./...\`*"
-          
-          # Post or update comment
-          gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT" --edit-last || \
-          gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT"
+  # Acceptance tests against a real, fully dockerized meshStack backend brought up from pre-built
+  # images as service containers. Runs on the org's self-hosted mesh-runners (which can pull the
+  # private GAR images); forks are skipped (no runners / secrets / MESHFED_REGISTRY variable).
+  # The internal registry path comes from the MESHFED_REGISTRY repo/org configuration variable so
+  # it is not hardcoded here. Canonical local equivalent: meshfed-release/docker-compose.acc.yml.
+  acceptance:
+    name: Go Acceptance Test
+    needs: [ build, test ]
+    # Run after the unit job (so its coverage artifact exists to merge) even when that job's tests
+    # failed, but only on a green build and on a non-fork PR or a manual dispatch (forks lack the
+    # self-hosted runners, the secrets and the MESHFED_REGISTRY variable).
+    if: >-
+      always() && needs.build.result == 'success' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: mesh-runners
+    permissions:
+      contents: read
+      pull-requests: write  # for the coverage comment
+
+    # ARC runs these self-hosted runners in kubernetes container mode, where a job using service
+    # containers MUST declare a job container — so nix-ci stays as the (GAR-available, proven) base.
+    # The Go toolchain + module/build cache come from actions/setup-go below, aligned with the other
+    # jobs in this workflow; tofu is provided by the nix-ci image.
+    container:
+      image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/nix-ci:latest
+
+    # Full backend as service containers. On mesh-runners all services + the job container share one
+    # network, so the images' baked localhost config resolves between them. Ports are de-conflicted
+    # (meshfed-api on 8089 so the tf-runner's fixed :8080 health server does not collide). JVM
+    # services use `--restart on-failure` to absorb the mariadb startup race; the readiness step is
+    # the real gate.
+    services:
+      mariadb:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/mariadb-ci
+
+      ravendb:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/ravendb-ci
+
+      rabbitmq:
+        image: ${{ vars.MESHFED_REGISTRY }}/dockerhub/rabbitmq:3.11.18-alpine
+        env:
+          RABBITMQ_DEFAULT_USER: guest
+          RABBITMQ_DEFAULT_PASS: guest
+
+      keycloak:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/keycloak-ci:26
+
+      meshfed-api:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/meshfed:latest
+        env:
+          SERVER_PORT: "8089"   # off 8080 so the tf-runner health server can have it; mgmt 8180
+        options: --restart on-failure
+
+      replicator:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/replicator:latest
+        env:
+          SERVER_PORT: "7080"   # move embedded server off 8080; mgmt 7180
+        options: --restart on-failure
+
+      block-coordinator-api:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/block-coordinator-api:latest
+        options: --restart on-failure
+
+      # Single poller of the magic runner UUID; fans work out by type. 127.0.0.1 forces IPv4 (the Go
+      # mux would otherwise resolve localhost to [::1], which Tomcat does not listen on). The mux
+      # holds no credentials: it forwards each runner's own Authorization on the claim, overriding
+      # only forRunnerUuid with the magic UUID.
+      multiplexing-block-runner:
+        image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/multiplexing-block-runner-ci:latest
+        env:
+          BB_RUNNER_MUX_UPSTREAM_URL: http://127.0.0.1:8089
+        options: --restart on-failure
+
+      # Standalone runners poll their mux port; own UUID is irrelevant (mux claims as the magic UUID),
+      # so it is an arbitrary placeholder. They authenticate with the seeded managed-runners API key
+      # (RUNNER_API_CLIENT_ID/SECRET → Bearer via POST /api/login, proxied through the mux) — the
+      # runner-scoped key, NOT the broad provider admin key (MESHSTACK_API_KEY) which only the
+      # provider client uses below. No basic auth. tf-block-runner bakes the matching dev private key
+      # (secret decryption works out of the box) and installs OpenTofu at runtime via Nix.
+      #
+      # Pinned to :main (not :latest): the building-block-runner repo only refreshes :latest on a
+      # tagged release, while :main is rebuilt on every merge to main. Tracking :main keeps the auth
+      # fixes (API-key-over-basic-auth precedence) that let the tf runner work in this acc stack.
+      tf-block-runner:
+        image: ghcr.io/meshcloud/tf-block-runner:main
+        env:
+          RUNNER_API_URL: http://127.0.0.1:8300
+          RUNNER_UUID: 11111111-1111-1111-1111-111111111111
+          RUNNER_API_CLIENT_ID: ${{ secrets.RUNNER_API_CLIENT_ID }}
+          RUNNER_API_CLIENT_SECRET: ${{ secrets.RUNNER_API_CLIENT_SECRET }}
+        options: --restart on-failure
+
+      manual-block-runner:
+        image: ghcr.io/meshcloud/manual-block-runner:main   # track merged main, see tf-block-runner
+        env:
+          RUNNER_API_URL: http://127.0.0.1:8301
+          RUNNER_UUID: 22222222-2222-2222-2222-222222222222
+          RUNNER_API_CLIENT_ID: ${{ secrets.RUNNER_API_CLIENT_ID }}
+          RUNNER_API_CLIENT_SECRET: ${{ secrets.RUNNER_API_CLIENT_SECRET }}
+          SERVER_PORT: "8104"   # move its embedded web server off 8080
+        options: --restart on-failure
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # Unit coverage data from the `test` job (a different runner). `continue-on-error` so a missing
+      # artifact (e.g. the unit job produced none) does not fail acceptance — the report step then
+      # falls back to acceptance-only coverage.
+      - name: Download unit coverage data
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: covdata-unit
+          path: covdata/unit
+
+      - name: Wait for backend to be ready
+        timeout-minutes: 8
+        shell: bash
+        run: |
+          wait_http() {
+            local url="$1" name="$2" deadline=$(( SECONDS + ${3:-360} ))
+            echo "waiting for $name ($url)..."
+            until curl -sf "$url" -o /dev/null; do
+              [ "$SECONDS" -gt "$deadline" ] && { echo "::error::timeout waiting for $name ($url)"; return 1; }
+              sleep 3
+            done
+            echo "$name healthy"
+          }
+          # meshfed-api is the gate: it bootstraps API keys into Keycloak, so tests run before it is
+          # healthy fail with auth errors.
+          wait_http http://localhost:8180/actuator/health meshfed-api 420
+          wait_http http://localhost:7180/actuator/health replicator 240
+          wait_http http://localhost:8083/actuator/health block-coordinator-api 240
+          wait_http http://localhost:8309/healthz mux 120
+          echo "mux routing:"; curl -s http://localhost:8309/status || true
+
+      - name: Run acceptance tests with coverage
+        id: acc
+        # Advisory: a failed acceptance run must never block the PR. The job runs against the last
+        # *merged* meshfed-release backend images, so a change needing a companion backend PR cannot
+        # go green here until that backend merges — gating on it would deadlock cross-repo changes.
+        # meshfed-release's source-built `terraform-provider-acceptance` job is the real gate; here we
+        # only surface failures via an advisory comment (see the last step).
+        continue-on-error: true
+        env:
+          # The acceptance API key/secret (seeded by the mariadb-ci dev dump) come from repo secrets.
+          MESHSTACK_ENDPOINT: http://localhost:8089
+          MESHSTACK_API_KEY: ${{ secrets.MESHSTACK_API_KEY }}
+          MESHSTACK_API_SECRET: ${{ secrets.MESHSTACK_API_SECRET }}
+          MESHSTACK_SKIP_VERSION_CHECK: "true"
+          TF_ACC: "1"
+          TF_ACC_PROVIDER_HOST: registry.opentofu.org
+        shell: bash
+        run: |
+          mkdir -p covdata/acc
+          export TF_ACC_TERRAFORM_PATH="$(command -v tofu)"
+          # The acceptance suite lives in ./internal/provider, but coverage is attributed across all
+          # packages via -coverpkg=./... so the merged report reflects the real end-to-end exercise of
+          # the client and helper packages too. Coverage is emitted as a binary coverage-data dir for
+          # merging with the unit job's data.
+          #
+          # Tee the output to a file so the next step can verify the run actually finished: a
+          # self-hosted-runner truncation can cut the test process short while this step still exits
+          # 0, which would otherwise pass as a green run. The default shell is `bash -eo pipefail`,
+          # so a genuine test failure still propagates through the pipe and fails this step.
+          go tool gotestsum --junitfile junit-acc.xml --format testdox -- \
+            -coverpkg=./... -count=1 -timeout 10m ./internal/provider/... \
+            -args -test.gocoverdir="$PWD/covdata/acc" 2>&1 | tee acc-output.log
+
+      # Guard against the self-hosted runner truncating/killing the test process while the step above
+      # still reports success (seen here, and in meshfed-release's e2e job). gotestsum prints a final
+      # "DONE N tests ... in Xs" summary only when the run completes, so its absence means the run was
+      # cut short and the result is UNKNOWN — fail hard so it can never be mistaken for green. This is
+      # distinct from an advisory test failure: a completed run (DONE present) keeps `continue-on-error`
+      # semantics below; only an incomplete run reds the job and demands a re-run. Exposes `complete`
+      # for the coverage/advisory steps. Sets the output before exiting so they can still read it.
+      - name: Verify acceptance run completed
+        id: acccheck
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ -s acc-output.log ] && grep -qE '^DONE [0-9]+ tests' acc-output.log; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+            echo "Acceptance run reached the gotestsum summary — the result is trustworthy."
+          else
+            echo "complete=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Acceptance run did not complete: no gotestsum 'DONE' summary in acc-output.log. The self-hosted runner truncated or killed the run, so the result is UNKNOWN (not a pass). Re-run the job."
+            exit 1
+          fi
+
+      # Merge the unit coverage (downloaded from the test job) with this job's acceptance coverage and
+      # rewrite the single coverage comment with the combined figure. Always runs — even when the
+      # acceptance tests fail the instrumented binaries still flush their coverage on exit — and
+      # annotates the combined row with the acceptance outcome / incompleteness.
+      - name: Report combined coverage on PR
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          ACC_OUTCOME: ${{ steps.acc.outcome }}
+          ACC_COMPLETE: ${{ steps.acccheck.outputs.complete }}
+        shell: bash
+        run: .github/scripts/coverage-comment.sh combined
+
+      # Advisory PR comment: the acceptance result never blocks (continue-on-error above). Post a
+      # comment when the latest run failed so the regression stays visible, and delete it once a later
+      # run goes green. Idempotent via the HTML marker; only on PRs (needs a PR number).
+      - name: Manage acceptance advisory comment
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          OUTCOME: ${{ steps.acc.outcome }}
+          COMPLETE: ${{ steps.acccheck.outputs.complete }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          MARKER='<!-- acceptance-advisory -->'
+
+          # Link straight to THIS acceptance job, not the run: the run page shows green on purpose
+          # (the acc step is continue-on-error), so the failing/truncated step is only visible inside
+          # the job. Resolve the job's html_url by matching the ephemeral runner that ran it; fall back
+          # to the run URL if the lookup fails.
+          RUN_URL="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
+          JOB_URL=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
+            --jq ".jobs[] | select(.runner_name == \"${RUNNER_NAME:-}\") | .html_url" 2>/dev/null | head -n1 || true)
+          [ -n "$JOB_URL" ] || JOB_URL="$RUN_URL"
+
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -n1 || true)
+
+          upsert() { # $1 = body
+            if [ -n "$existing" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$1" >/dev/null
+              echo "updated advisory comment $existing"
+            else
+              gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$1" >/dev/null
+              echo "posted advisory comment"
+            fi
+          }
+
+          # Incomplete run (truncated/killed by the runner): the result is unknown, so surface it
+          # loudly and never delete an existing warning by mistaking it for a pass.
+          if [ "$COMPLETE" != "true" ]; then
+            upsert "$(printf '%s\n%s\n\n%s' "$MARKER" \
+              "🛑 **The acceptance run did not complete.** The self-hosted runner truncated or killed the test process before gotestsum reported a summary, so the result is **unknown — not a pass**. Re-run the job; if it recurs it is a runner-infra issue." \
+              "🔗 [View the acceptance job]($JOB_URL)")"
+            exit 0
+          fi
+
+          # Completed run — act only on a definitive pass/fail; ignore cancelled/skipped.
+          case "$OUTCOME" in
+            success)
+              if [ -n "$existing" ]; then
+                gh api -X DELETE "repos/$REPO/issues/comments/$existing"
+                echo "acceptance green — deleted advisory comment $existing"
+              else
+                echo "acceptance green — no advisory comment to delete"
+              fi
+              ;;
+            failure)
+              upsert "$(printf '%s\n%s\n\n%s' "$MARKER" \
+                "⚠️ **Acceptance tests failed on the latest run.** This is advisory and does **not** block merge — the job runs against the last merged meshfed-release backend images. If this change needs a companion backend change, validate the pair via meshfed-release's \`terraform-provider-acceptance\` job; otherwise this is a regression to fix." \
+                "🔗 [View the failing acceptance job]($JOB_URL)")"
+              ;;
+            *)
+              echo "acceptance outcome '$OUTCOME' — leaving any existing comment untouched"
+              ;;
+          esac


### PR DESCRIPTION
## What

Adds a dockerized **acceptance-test job** to the `Tests` workflow (`.github/workflows/test.yml`) that brings up the **entire meshStack backend from pre-built images** as GitHub Actions service containers on the self-hosted `mesh-runners`, then runs the provider acceptance suite (`go tool gotestsum … ./internal/provider/…`) against it and merges its coverage with the unit job's.

Stack (all pulled, none built in this repo):
- infra: `mariadb-ci`, `ravendb-ci`, `keycloak-ci:26`, `rabbitmq`
- services: `meshfed` (8089), `replicator`, `block-coordinator-api`
- building-block fan-out: `multiplexing-block-runner-ci` (mux) + `tf-block-runner` + `manual-block-runner`

## Design notes

- Internal registry path comes from the **`MESHFED_REGISTRY` repo configuration variable** (not hardcoded in this public repo). `env` context isn't allowed in `services.image`, so a `vars.*` configuration variable is used.
- meshfed-api runs on **8089** so the tf-runner's fixed `:8080` health server doesn't collide (matches meshfed-release CI).
- JVM services use `--restart on-failure` to absorb the mariadb startup race; a readiness step gates the tests.
- Runners authenticate with the seeded **managed-runners** API key (runner-scoped rights), not the provider admin key.
- Coverage: the unit job's coverage data is merged with the acceptance job's into the single PR coverage comment.
- The canonical local equivalent is `meshfed-release/docker-compose.acc.yml` (private repo); this workflow is the native-`services:` translation.
- Runs on non-fork PRs and `workflow_dispatch` only (forks lack self-hosted runners / the variable).

## Advisory (non-blocking) gating

The acceptance job runs against the **last merged** meshfed-release backend images, so a provider change that needs a companion backend change can't go green here until that backend merges. To avoid a cross-repo merge deadlock, this job is **advisory**:

- `continue-on-error` keeps the `Go Acceptance Test` check green regardless of result (it is not a required check).
- When the latest run fails, a PR comment is posted with a link to the run log; it is auto-deleted once a later run goes green again (idempotent via an HTML marker).

The authoritative cross-repo gate is meshfed-release's source-built `terraform-provider-acceptance` job, which pairs the same-named provider branch and builds the backend from that PR's source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
