### PR TITLE
test: verify Entra ID integration can be renamed

### DIFF
--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -203,12 +203,18 @@ func TestAccIntegrationResource(t *testing.T) {
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
-				// NOTE: no display_name update step here (unlike the other integration types).
-				// meshfed's EntraIdIntegrationHandler.update ignores model.name — it updates only
-				// tenant_id/client_id/client_secret and reuses the stale name — so renaming an Entra
-				// ID integration is silently dropped by the backend, which surfaces as a Terraform
-				// "inconsistent result after apply". Re-add an update step once the backend persists
-				// the name. Tracked by the meshfed-release fix PR.
+				{
+					Config: updateIntegrationDisplayName(t, config, "Entra ID Integration"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(resourceAddress.String(), plancheck.ResourceActionUpdate),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("04_entra_id", "Entra ID Updated Integration")),
+						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
+					},
+				},
 				{
 					ImportState:     true,
 					ImportStateKind: resource.ImportBlockWithID,


### PR DESCRIPTION
## What

Follow-up to #210. Restores the `display_name` update step in the `04_entra_id` acceptance subtest so it verifies an Entra ID integration can be **renamed** (create → rename → import).

## Why now

#210 dropped that step because meshfed's `EntraIdIntegrationHandler.update` silently ignored `model.name` (rename was a no-op, surfacing as `inconsistent result after apply`). The backend fix is meshcloud/meshfed-release#10225, which persists the name on update.

## Cross-repo pairing

This branch is named **`feature/entra-id-integration-rename`** to match the meshfed-release PR branch. meshfed-release's `terraform-provider-acceptance` job resolves the provider branch from `github.head_ref` and falls back to `main` — so with matching names it pairs the two and validates the rename against the **fixed** backend.

> ⚠️ This provider PR's own acceptance job runs against the last *merged* meshfed-release backend images, which do **not** yet contain the fix, so the rename step will fail here (advisory-only on PRs) until #10225 merges and ships in the images. The authoritative signal is the paired run in meshfed-release#10225.

Mock-mode unit tests and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)