### PR TITLE
chore(ci): group Dependabot updates + document SHA verification and PR stacking

### DIFF
--- a/.agents/skills/github-ci/SKILL.md
+++ b/.agents/skills/github-ci/SKILL.md
@@ -32,6 +32,11 @@ gh api repos/actions/checkout/git/refs/tags/v6.0.2 --jq '.object.sha'        # r
 
 Then update both the SHA and the `# vX.Y.Z` comment. Use latest stable versions; check periodically.
 
+**Adding a *new* action** (a step not yet in the workflows): resolve the **latest** release with the
+two commands above and pin to that SHA. Do **not** copy a SHA/version out of a scaffolding template,
+another repo, or an old example — that is how an action lands already several majors behind on the
+day it is introduced.
+
 ## Jobs in `test.yml`
 
 All gated on `build` succeeding first.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Combine Go module updates into a single PR instead of one PR per module.
+    groups:
+      go-modules:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Combine all GitHub Actions bumps into a single PR (including major versions),
+    # so they can be reviewed and merged together rather than one PR per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"


### PR DESCRIPTION
Top of the Dependabot action-bump stack (#206 → #214 → #213 → #212 → this).

- **`.github/dependabot.yml`**: add wildcard `groups:` to both ecosystems so future updates arrive as **one combined PR per ecosystem** (github-actions incl. majors) instead of one PR per dependency — so this manual re-stacking is not needed next time.
- **`.agents/skills/github-ci/SKILL.md`**: when introducing a *new* action, resolve the latest release SHA rather than copying a stale SHA from a template/old example (root cause of actions landing several majors behind on day one).

Merging the whole stack: fast-forward `main` to this branch —
`git push origin chore/dependabot-grouping-and-ci-skill:main` — which lands all five PRs at once (GitHub auto-closes each as merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)