### PR TITLE
feat: deprecate meshstack_tenant in favor of meshstack_tenant_v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.23.1
+
+DEPRECATIONS:
+- `meshstack_tenant`: deprecated in favor of `meshstack_tenant_v4`. Only `meshstack_tenant_v4` exposes the tenant `uuid` (and a `ref`) required to target tenants from the `meshstack_building_block` resource. Using `meshstack_tenant` now emits a deprecation warning. There is no automatic state migration between the two resource types; move existing tenants over by importing them into `meshstack_tenant_v4`.
+
 # v0.23.0
 
 FEATURES:

--- a/internal/provider/tenant_resource.go
+++ b/internal/provider/tenant_resource.go
@@ -43,6 +43,7 @@ func (r *tenantResource) Configure(_ context.Context, req resource.ConfigureRequ
 func (r *tenantResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Single tenant by workspace, project, and platform.",
+		DeprecationMessage:  "Use `meshstack_tenant_v4` instead, which exposes the tenant `uuid` (and a `ref`) required to target tenants from `meshstack_building_block`. There is no automatic state migration between the two resource types; move existing tenants over by importing them into `meshstack_tenant_v4`.",
 
 		Attributes: map[string]schema.Attribute{
 			"metadata": schema.SingleNestedAttribute{


### PR DESCRIPTION
## What

Deprecate the legacy `meshstack_tenant` resource in favor of `meshstack_tenant_v4`.

## Why

Only `meshstack_tenant_v4` exposes the tenant `uuid` (and a `ref`), which `meshstack_building_block`
requires to target a tenant (`target_ref` for a `meshTenant` needs a uuid). `meshstack_tenant`
cannot be used to wire up building blocks, so it should no longer be the default choice.

## Changes

- Add a `DeprecationMessage` to the `meshstack_tenant` resource schema pointing at
  `meshstack_tenant_v4`. Terraform/OpenTofu now emit a deprecation warning when the resource is used.
- CHANGELOG: new `v0.23.1` section with a `DEPRECATIONS` entry.

## Migration note

There is **no** automatic state migration between the two resource types (no state mover / `moved`
support), so the message tells users to move existing tenants over by **importing** them into
`meshstack_tenant_v4` rather than promising a `moved` block.

## Validation

- `go build ./...`, `task lint` (0 issues), `task test` tenant suite (mock) all green.
- `task generate` is a no-op for docs — the repo's doc template doesn't render resource-level
  `DeprecationMessage` (same as the already-deprecated `meshstack_buildingblock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
