### PR TITLE
feat: allow to manage display_order value for building block definiti…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ providers-schema.json
 
 dist/
 
+bin/
+
 scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.23.1
 
 FEATURES:
-- `meshstack_building_block_definition`: `version_spec.inputs` and `version_spec.outputs` now support an optional `display_order` (number) attribute that controls how inputs/outputs are arranged in meshPanel. It defaults to `0` when omitted and is intentionally excluded from a version's `content_hash`, so reordering does not create a version change.
+- `meshstack_building_block_definition`: `version_spec.inputs` and `version_spec.outputs` now support an optional `display_order` (number) attribute that controls how inputs/outputs are arranged in meshPanel. It defaults to `0` when omitted.
 
 FIXES:
 - `meshstack_building_block`: Prepare for the upcoming `WAITING_FOR_APPROVAL` run status (an approval gate coming soon to meshStack — not available yet). Once meshStack starts returning it, an awaited create/update where the run parks for approval will complete with a "waiting for input" warning instead of failing with "unknown building block status; provider may be out of date".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# v0.23.1
+# v0.23.2
 
 FEATURES:
-- `meshstack_building_block_definition`: `version_spec.inputs` and `version_spec.outputs` now support an optional `display_order` (number) attribute that controls how inputs/outputs are arranged in meshPanel. It defaults to `0` when omitted.
+- `meshstack_building_block_definition`: `version_spec.inputs` and `version_spec.outputs` now support an optional `display_order` (number) attribute that controls how inputs/outputs are arranged in meshPanel. It defaults to the already set value when omitted, or `0` if there is none.
+
+# v0.23.1
 
 FIXES:
 - `meshstack_building_block`: Prepare for the upcoming `WAITING_FOR_APPROVAL` run status (an approval gate coming soon to meshStack — not available yet). Once meshStack starts returning it, an awaited create/update where the run parks for approval will complete with a "waiting for input" warning instead of failing with "unknown building block status; provider may be out of date".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.23.1
 
+FEATURES:
+- `meshstack_building_block_definition`: `version_spec.inputs` and `version_spec.outputs` now support an optional `display_order` (number) attribute that controls how inputs/outputs are arranged in meshPanel. It defaults to `0` when omitted and is intentionally excluded from a version's `content_hash`, so reordering does not create a version change.
+
 FIXES:
 - `meshstack_building_block`: Prepare for the upcoming `WAITING_FOR_APPROVAL` run status (an approval gate coming soon to meshStack — not available yet). Once meshStack starts returning it, an awaited create/update where the run parks for approval will complete with a "waiting for input" warning instead of failing with "unknown building block status; provider may be out of date".
 - `meshstack_building_block_definition`: `Read` now derives `version_spec.draft` from the definition's actual latest version instead of retaining the prior state value. Previously, when the latest version was switched to a draft outside Terraform, refresh kept `draft = false`, so a `draft = false -> true` change created a redundant new version instead of reconciling the existing draft in place.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 - `meshstack_building_block_definition`: `version_spec.inputs` and `version_spec.outputs` now support an optional `display_order` (number) attribute that controls how inputs/outputs are arranged in meshPanel. It defaults to the already set value when omitted, or `0` if there is none.
 
+FIXES:
+- `meshstack_building_block`: A `content_hash` wired from a definition's computed `content_hash` no longer triggers a re-run when the value changed only because the hash-algorithm version changed (e.g. after upgrading the provider). Such version-only differences are now recognized and ignored, while genuine content changes still re-run. Setting an arbitrary (non-versioned) `content_hash` to force a manual re-run continues to work.
+
 # v0.23.1
 
 FIXES:

--- a/client/building_block_definition_version.go
+++ b/client/building_block_definition_version.go
@@ -112,6 +112,7 @@ type MeshBuildingBlockDefinitionInput struct {
 	Description                 *string           `json:"description,omitempty" tfsdk:"description"`
 	ValueValidationRegex        *string           `json:"valueValidationRegex,omitempty" tfsdk:"value_validation_regex"`
 	ValidationRegexErrorMessage *string           `json:"validationRegexErrorMessage,omitempty" tfsdk:"validation_regex_error_message"`
+	DisplayOrder                int64             `json:"displayOrder,omitempty" tfsdk:"display_order"`
 }
 
 func (m *MeshBuildingBlockDefinitionInput) UnmarshalJSON(bytes []byte) error {
@@ -148,6 +149,7 @@ type MeshBuildingBlockDefinitionOutput struct {
 	DisplayName    string                                          `json:"displayName" tfsdk:"display_name"`
 	Type           MeshBuildingBlockIOType                         `json:"type" tfsdk:"type"`
 	AssignmentType MeshBuildingBlockDefinitionOutputAssignmentType `json:"assignmentType" tfsdk:"assignment_type"`
+	DisplayOrder   int64                                           `json:"displayOrder,omitempty" tfsdk:"display_order"`
 }
 
 // Main version types

--- a/docs/resources/building_block.md
+++ b/docs/resources/building_block.md
@@ -134,7 +134,7 @@ Required:
 
 Optional:
 
-- `content_hash` (String) Content hash of the building block definition version. Its purpose is to detect content changes of a **draft** BBD (whose version `uuid` stays the same) and conveniently re-run the building block when it changes.<br>It is provider-only and never sent to the backend, so changing it can also be used to force a manual re-run — use with care; with a plain workspace key (`BUILDINGBLOCK_SAVE`) this requires the definition to have run transparency enabled (admins and the definition's platform operator are exempt).<br>After import it is left null in state, so the first apply triggers a run if `content_hash` is set in config. To avoid that, omit `content_hash` until after the first post-import apply, or set it only then.
+- `content_hash` (String) Content hash of the building block definition version. Its purpose is to detect content changes of a **draft** BBD (whose version `uuid` stays the same) and conveniently re-run the building block when it changes.<br>When wired from a definition's computed `content_hash`, a change caused *only* by a hash-algorithm version upgrade (e.g. after upgrading the provider) does **not** trigger a re-run.<br>It is provider-only and never sent to the backend, so changing it can also be used to force a manual re-run — use with care; with a plain workspace key (`BUILDINGBLOCK_SAVE`) this requires the definition to have run transparency enabled (admins and the definition's platform operator are exempt).<br>After import it is left null in state, so the first apply triggers a run if `content_hash` is set in config. To avoid that, omit `content_hash` until after the first post-import apply, or set it only then.
 
 
 <a id="nestedatt--spec--inputs"></a>

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -74,7 +74,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         updateable_by_consumer         = true                                                                      # Optional: defaults to false
         value_validation_regex         = "^[a-z0-9-]+$"                                                            # Optional
         validation_regex_error_message = "Resource name must contain only lowercase letters, numbers, and hyphens" # Optional
-        display_order                  = 2                                                                         # Optional: only arranges inputs in meshPanel, ignored by the content hash
+        display_order                  = 2                                                                         # Optional: arranges inputs in meshPanel; part of the content hash, so it cannot change on a released version
       }
       SOMETHING_VERY_SECRET = {
         display_name    = "Top Secret"
@@ -572,7 +572,7 @@ Optional:
 - `argument` (String) Argument value for the input, depending on the assignment type. **Required** if `assignment_type` is `STATIC`, `BUILDING_BLOCK_OUTPUT`. **Must not be provided** for other assignment types.<br>For assignment type `BUILDING_BLOCK_OUTPUT`, the value must have the format `jsonencode("<BuildingBlockDefinitionUuid>.<outputName>")`.<br>The value must be passed through `jsonencode()` to support dynamic typing as defined by the `type` attribute.<br>For type `CODE`, the value must be an `jsonencode`'d string, e.g. `jsonencode("some code")` and the interpretation of the `"some code"` string is implementation-specific.<br>For the `terraform` implementation, the `CODE` input value should be `jsonencode`'d again, as any JSON is a valid HCL expression, which is properly passed to a variable input by the TF runner.<br>For example, if the variable input specifies `type = map(string)`, then a type-matching value input is `jsonencode(jsonencode({some-key: "some-value"}))`.
 - `default_value` (String) Default value for the input. **Can only be provided** if `assignment_type` is `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`. Must be passed through `jsonencode()` to match the `type` attribute.
 - `description` (String) Description explaining the purpose and usage of the input.
-- `display_order` (Number) Numeric value controlling the display ordering of this input in meshPanel. Used only for arranging inputs; it does not affect the version's content hash. Defaults to `0` when omitted.
+- `display_order` (Number) Numeric value controlling the display ordering of this input in meshPanel. It is part of the version's content hash, so it cannot be changed on a released version. Defaults to `0` when omitted.
 - `is_environment` (Boolean) Whether this input is exposed as an environment variable (when `true`) or as a regular variable (when `false`).
 - `selectable_values` (Set of String) Set of allowed values for the input. **Required** to be non-empty when `type` is `SINGLE_SELECT` or `MULTI_SELECT`.
 - `sensitive` (Attributes) Configuration for sensitive input values. **Mutually exclusive** with the non-sensitive `argument` and `default_value` attributes. When an input is marked as sensitive, use the nested `sensitive.argument` or `sensitive.default_value` instead of the top-level attributes. You can provide an empty attribute `sensitive = {}` to mark this input as sensitive without providing values. Sensitive inputs are **only supported** for `assignment_type` of `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, `STATIC`. (see [below for nested schema](#nestedatt--version_spec--inputs--sensitive))
@@ -633,7 +633,7 @@ Required:
 Optional:
 
 - `assignment_type` (String) How the output is used. One of `NONE`, `PLATFORM_TENANT_ID`, `SIGN_IN_URL`, `RESOURCE_URL`, `SUMMARY`. Defaults to `NONE`.
-- `display_order` (Number) Numeric value controlling the display ordering of this output in meshPanel. Used only for arranging outputs; it does not affect the version's content hash. Defaults to `0` when omitted.
+- `display_order` (Number) Numeric value controlling the display ordering of this output in meshPanel. It is part of the version's content hash, so it cannot be changed on a released version. Defaults to `0` when omitted.
 
 
 <a id="nestedatt--version_spec--runner_ref"></a>

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -572,7 +572,7 @@ Optional:
 - `argument` (String) Argument value for the input, depending on the assignment type. **Required** if `assignment_type` is `STATIC`, `BUILDING_BLOCK_OUTPUT`. **Must not be provided** for other assignment types.<br>For assignment type `BUILDING_BLOCK_OUTPUT`, the value must have the format `jsonencode("<BuildingBlockDefinitionUuid>.<outputName>")`.<br>The value must be passed through `jsonencode()` to support dynamic typing as defined by the `type` attribute.<br>For type `CODE`, the value must be an `jsonencode`'d string, e.g. `jsonencode("some code")` and the interpretation of the `"some code"` string is implementation-specific.<br>For the `terraform` implementation, the `CODE` input value should be `jsonencode`'d again, as any JSON is a valid HCL expression, which is properly passed to a variable input by the TF runner.<br>For example, if the variable input specifies `type = map(string)`, then a type-matching value input is `jsonencode(jsonencode({some-key: "some-value"}))`.
 - `default_value` (String) Default value for the input. **Can only be provided** if `assignment_type` is `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`. Must be passed through `jsonencode()` to match the `type` attribute.
 - `description` (String) Description explaining the purpose and usage of the input.
-- `display_order` (Number) Numeric value controlling the display ordering of this input in meshPanel. It is part of the version's content hash, so it cannot be changed on a released version. Defaults to `0` when omitted.
+- `display_order` (Number) Numeric value controlling in which order the inputs are displayed in the UI. Cannot be changed on a released version. When omitted, uses existing value, if any. Otherwise defaults to `0`.
 - `is_environment` (Boolean) Whether this input is exposed as an environment variable (when `true`) or as a regular variable (when `false`).
 - `selectable_values` (Set of String) Set of allowed values for the input. **Required** to be non-empty when `type` is `SINGLE_SELECT` or `MULTI_SELECT`.
 - `sensitive` (Attributes) Configuration for sensitive input values. **Mutually exclusive** with the non-sensitive `argument` and `default_value` attributes. When an input is marked as sensitive, use the nested `sensitive.argument` or `sensitive.default_value` instead of the top-level attributes. You can provide an empty attribute `sensitive = {}` to mark this input as sensitive without providing values. Sensitive inputs are **only supported** for `assignment_type` of `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, `STATIC`. (see [below for nested schema](#nestedatt--version_spec--inputs--sensitive))
@@ -633,7 +633,7 @@ Required:
 Optional:
 
 - `assignment_type` (String) How the output is used. One of `NONE`, `PLATFORM_TENANT_ID`, `SIGN_IN_URL`, `RESOURCE_URL`, `SUMMARY`. Defaults to `NONE`.
-- `display_order` (Number) Numeric value controlling the display ordering of this output in meshPanel. It is part of the version's content hash, so it cannot be changed on a released version. Defaults to `0` when omitted.
+- `display_order` (Number) Numeric value controlling in which order the outputs are displayed in the UI. Cannot be changed on a released version. When omitted, uses existing value, if any. Otherwise defaults to `0`.
 
 
 <a id="nestedatt--version_spec--runner_ref"></a>

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -63,6 +63,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         type              = "SINGLE_SELECT"
         assignment_type   = "USER_INPUT"
         selectable_values = ["dev", "prod", "staging"] # Optional, must be non-empty
+        display_order     = 1
       }
       resource_name = {
         display_name                   = "Resource Name"
@@ -73,6 +74,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         updateable_by_consumer         = true                                                                      # Optional: defaults to false
         value_validation_regex         = "^[a-z0-9-]+$"                                                            # Optional
         validation_regex_error_message = "Resource name must contain only lowercase letters, numbers, and hyphens" # Optional
+        display_order                  = 2                                                                         # Optional: only arranges inputs in meshPanel, ignored by the content hash
       }
       SOMETHING_VERY_SECRET = {
         display_name    = "Top Secret"
@@ -127,11 +129,13 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         display_name    = "If true, it really worked"
         type            = "BOOLEAN"
         assignment_type = "NONE"
+        display_order   = 1
       }
       summary = {
         display_name    = "Summary of work"
         type            = "STRING"
         assignment_type = "SUMMARY"
+        display_order   = 2
       }
     }
 
@@ -568,6 +572,7 @@ Optional:
 - `argument` (String) Argument value for the input, depending on the assignment type. **Required** if `assignment_type` is `STATIC`, `BUILDING_BLOCK_OUTPUT`. **Must not be provided** for other assignment types.<br>For assignment type `BUILDING_BLOCK_OUTPUT`, the value must have the format `jsonencode("<BuildingBlockDefinitionUuid>.<outputName>")`.<br>The value must be passed through `jsonencode()` to support dynamic typing as defined by the `type` attribute.<br>For type `CODE`, the value must be an `jsonencode`'d string, e.g. `jsonencode("some code")` and the interpretation of the `"some code"` string is implementation-specific.<br>For the `terraform` implementation, the `CODE` input value should be `jsonencode`'d again, as any JSON is a valid HCL expression, which is properly passed to a variable input by the TF runner.<br>For example, if the variable input specifies `type = map(string)`, then a type-matching value input is `jsonencode(jsonencode({some-key: "some-value"}))`.
 - `default_value` (String) Default value for the input. **Can only be provided** if `assignment_type` is `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`. Must be passed through `jsonencode()` to match the `type` attribute.
 - `description` (String) Description explaining the purpose and usage of the input.
+- `display_order` (Number) Numeric value controlling the display ordering of this input in meshPanel. Used only for arranging inputs; it does not affect the version's content hash. Defaults to `0` when omitted.
 - `is_environment` (Boolean) Whether this input is exposed as an environment variable (when `true`) or as a regular variable (when `false`).
 - `selectable_values` (Set of String) Set of allowed values for the input. **Required** to be non-empty when `type` is `SINGLE_SELECT` or `MULTI_SELECT`.
 - `sensitive` (Attributes) Configuration for sensitive input values. **Mutually exclusive** with the non-sensitive `argument` and `default_value` attributes. When an input is marked as sensitive, use the nested `sensitive.argument` or `sensitive.default_value` instead of the top-level attributes. You can provide an empty attribute `sensitive = {}` to mark this input as sensitive without providing values. Sensitive inputs are **only supported** for `assignment_type` of `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, `STATIC`. (see [below for nested schema](#nestedatt--version_spec--inputs--sensitive))
@@ -628,6 +633,7 @@ Required:
 Optional:
 
 - `assignment_type` (String) How the output is used. One of `NONE`, `PLATFORM_TENANT_ID`, `SIGN_IN_URL`, `RESOURCE_URL`, `SUMMARY`. Defaults to `NONE`.
+- `display_order` (Number) Numeric value controlling the display ordering of this output in meshPanel. Used only for arranging outputs; it does not affect the version's content hash. Defaults to `0` when omitted.
 
 
 <a id="nestedatt--version_spec--runner_ref"></a>

--- a/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
+++ b/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
@@ -45,6 +45,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         type              = "SINGLE_SELECT"
         assignment_type   = "USER_INPUT"
         selectable_values = ["dev", "prod", "staging"] # Optional, must be non-empty
+        display_order     = 1
       }
       resource_name = {
         display_name                   = "Resource Name"
@@ -55,6 +56,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         updateable_by_consumer         = true                                                                      # Optional: defaults to false
         value_validation_regex         = "^[a-z0-9-]+$"                                                            # Optional
         validation_regex_error_message = "Resource name must contain only lowercase letters, numbers, and hyphens" # Optional
+        display_order                  = 2                                                                         # Optional: only arranges inputs in meshPanel, ignored by the content hash
       }
       SOMETHING_VERY_SECRET = {
         display_name    = "Top Secret"
@@ -109,11 +111,13 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         display_name    = "If true, it really worked"
         type            = "BOOLEAN"
         assignment_type = "NONE"
+        display_order   = 1
       }
       summary = {
         display_name    = "Summary of work"
         type            = "STRING"
         assignment_type = "SUMMARY"
+        display_order   = 2
       }
     }
 

--- a/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
+++ b/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
@@ -56,7 +56,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         updateable_by_consumer         = true                                                                      # Optional: defaults to false
         value_validation_regex         = "^[a-z0-9-]+$"                                                            # Optional
         validation_regex_error_message = "Resource name must contain only lowercase letters, numbers, and hyphens" # Optional
-        display_order                  = 2                                                                         # Optional: only arranges inputs in meshPanel, ignored by the content hash
+        display_order                  = 2                                                                         # Optional: arranges inputs in meshPanel; part of the content hash, so it cannot change on a released version
       }
       SOMETHING_VERY_SECRET = {
         display_name    = "Top Secret"

--- a/internal/clientmock/mock_building_block_definition_version.go
+++ b/internal/clientmock/mock_building_block_definition_version.go
@@ -87,6 +87,7 @@ func applyManualOutputBehavior(versionSpec *client.MeshBuildingBlockDefinitionVe
 			DisplayName:    input.DisplayName,
 			Type:           translateManualInputTypeToOutput(input.Type),
 			AssignmentType: assignmentType,
+			DisplayOrder:   input.DisplayOrder,
 		}
 	}
 	versionSpec.Outputs = outputs

--- a/internal/provider/building_block_definition_resource.go
+++ b/internal/provider/building_block_definition_resource.go
@@ -218,6 +218,27 @@ func outputAssignmentTypes(outputs types.Map) map[string]string {
 	return result
 }
 
+func displayOrdersDiffer(a, b client.MeshBuildingBlockDefinitionVersionSpec) bool {
+	inputOrders := func(m map[string]*client.MeshBuildingBlockDefinitionInput) map[string]int64 {
+		orders := make(map[string]int64, len(m))
+		for key, input := range m {
+			if input != nil {
+				orders[key] = input.DisplayOrder
+			}
+		}
+		return orders
+	}
+	outputOrders := func(m map[string]client.MeshBuildingBlockDefinitionOutput) map[string]int64 {
+		orders := make(map[string]int64, len(m))
+		for key, output := range m {
+			orders[key] = output.DisplayOrder
+		}
+		return orders
+	}
+	return !maps.Equal(inputOrders(a.Inputs), inputOrders(b.Inputs)) ||
+		!maps.Equal(outputOrders(a.Outputs), outputOrders(b.Outputs))
+}
+
 // platformTenantIdOutputKeysEqual reports whether the set of output keys assigned PLATFORM_TENANT_ID is
 // the same in both maps. Used to detect whether a manual building block's configured tenant-id output
 // changed, which (besides an inputs change) is the only way its reconciled outputs can change.
@@ -495,6 +516,15 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 			return
 		}
 		if versionSpecDtoContentHash == state.VersionLatest.ContentHash.Get() {
+			// display_order is excluded from the content hash, so an equal hash could still mean changed display_order.
+			// Released versions are immutable, so reject a display_order-only change explicitly
+			if displayOrdersDiffer(plan.VersionSpec.MeshBuildingBlockDefinitionVersionSpec, state.VersionSpec.MeshBuildingBlockDefinitionVersionSpec) {
+				resp.Diagnostics.AddError("Error updating version_spec", fmt.Sprintf(
+					"Changing display_order on a released version %d is not allowed — released versions are immutable.",
+					state.VersionLatest.Number.Get(),
+				))
+				return
+			}
 			// state is in draft=false (aka released), and there's no change in version_spec,
 			// so all is good, and we don't need to do anything with the backend
 			return

--- a/internal/provider/building_block_definition_resource.go
+++ b/internal/provider/building_block_definition_resource.go
@@ -494,11 +494,30 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if !versionSpecDtoContentHash.indicatesChangesTowardsHash(state.VersionLatest.ContentHash.Get()) {
+
+		cmp := versionSpecDtoContentHash.compareToStored(state.VersionLatest.ContentHash.Get())
+		if cmp == hashIncomparable {
+			// The stored hash was produced by a different/legacy algorithm version (state written by an
+			// older provider and never refreshed, imported, or planned with -refresh=false), so its value
+			// cannot be compared against the current-version hash. Recompute the released version's hash
+			// from the authoritative spec in state AT THE CURRENT version so we compare like-for-like
+			// instead of guessing "no change". We build the DTO straight from state.VersionSpec (not via
+			// versionSpecDtoFromPlan, which would pull a manual BBD's outputs from the new config and
+			// thus mask a real change) — mirroring how the stored hash was originally derived from state.
+			stateSpecDto := state.VersionSpec.ToClientDto(bbdUuid)
+			authoritative := calculateBuildingBlockDefinitionVersionContentHash(stateSpecDto, &resp.Diagnostics)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			cmp = versionSpecDtoContentHash.compareToStored(authoritative.toBase64())
+		}
+
+		switch cmp {
+		case hashSame:
 			// state is in draft=false (aka released), and there's no indication of change in version_specs,
 			// so all is good, and we don't need to do anything with the backend
 			return
-		} else {
+		default: // hashDifferent, or still-incomparable -> fail safe by rejecting a change to an immutable version
 			resp.Diagnostics.AddError("Error updating version_spec", fmt.Sprintf(
 				"Updating a version_spec in non-draft (released) state is not allowed — released versions are immutable.\n\n"+
 					"To publish your changes as a new version, first set draft = true and apply to create a draft. "+
@@ -537,7 +556,7 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if updatedVersionSpecContentHash.indicatesChangesTowardsHash(plan.VersionLatest.ContentHash.Get()) {
+		if updatedVersionSpecContentHash.compareToStored(plan.VersionLatest.ContentHash.Get()) == hashDifferent {
 			resp.Diagnostics.AddError("Inconsistent content hash of version_spec after update", fmt.Sprintf(
 				"The content hash of the latest version after listing does not match the content hash of the updated/created response: %s != %s. "+
 					"This is most likely a bug in the backend.",

--- a/internal/provider/building_block_definition_resource.go
+++ b/internal/provider/building_block_definition_resource.go
@@ -500,10 +500,8 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 			// The stored hash was produced by a different/legacy algorithm version (state written by an
 			// older provider and never refreshed, imported, or planned with -refresh=false), so its value
 			// cannot be compared against the current-version hash. Recompute the released version's hash
-			// from the authoritative spec in state AT THE CURRENT version so we compare like-for-like
-			// instead of guessing "no change". We build the DTO straight from state.VersionSpec (not via
-			// versionSpecDtoFromPlan, which would pull a manual BBD's outputs from the new config and
-			// thus mask a real change) — mirroring how the stored hash was originally derived from state.
+			// from the authoritative spec in state AT THE CURRENT version so we compare.
+			// We build the DTO straight from state.VersionSpec.
 			stateSpecDto := state.VersionSpec.ToClientDto(bbdUuid)
 			authoritative := calculateBuildingBlockDefinitionVersionContentHash(stateSpecDto, &resp.Diagnostics)
 			if resp.Diagnostics.HasError() {

--- a/internal/provider/building_block_definition_resource.go
+++ b/internal/provider/building_block_definition_resource.go
@@ -218,27 +218,6 @@ func outputAssignmentTypes(outputs types.Map) map[string]string {
 	return result
 }
 
-func displayOrdersDiffer(a, b client.MeshBuildingBlockDefinitionVersionSpec) bool {
-	inputOrders := func(m map[string]*client.MeshBuildingBlockDefinitionInput) map[string]int64 {
-		orders := make(map[string]int64, len(m))
-		for key, input := range m {
-			if input != nil {
-				orders[key] = input.DisplayOrder
-			}
-		}
-		return orders
-	}
-	outputOrders := func(m map[string]client.MeshBuildingBlockDefinitionOutput) map[string]int64 {
-		orders := make(map[string]int64, len(m))
-		for key, output := range m {
-			orders[key] = output.DisplayOrder
-		}
-		return orders
-	}
-	return !maps.Equal(inputOrders(a.Inputs), inputOrders(b.Inputs)) ||
-		!maps.Equal(outputOrders(a.Outputs), outputOrders(b.Outputs))
-}
-
 // platformTenantIdOutputKeysEqual reports whether the set of output keys assigned PLATFORM_TENANT_ID is
 // the same in both maps. Used to detect whether a manual building block's configured tenant-id output
 // changed, which (besides an inputs change) is the only way its reconciled outputs can change.
@@ -394,12 +373,12 @@ func (r *buildingBlockDefinitionResource) ModifyPlan(ctx context.Context, req re
 			return
 		}
 		if tfValue.IsFullyKnown() {
-			result.Value = new(versionContentHash(
+			result.Value = new(calculateBuildingBlockDefinitionVersionContentHash(
 				generic.GetAttribute[client.MeshBuildingBlockDefinitionVersionSpec](
 					ctx, req.Plan, versionSpecPath, &resp.Diagnostics,
 					buildingBlockDefinitionVersionConverterOptions(ctx, req.Config, req.Plan, req.State)...),
 				&resp.Diagnostics,
-			))
+			).toBase64())
 		}
 		return
 	}()
@@ -511,21 +490,12 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 		// this makes released or in-review versions immutable. A secret rotation on a released version is
 		// already rejected at plan time in ModifyPlan with a clear message (issue #196), so it never reaches
 		// here; any remaining version_spec change is caught by the content-hash comparison below.
-		versionSpecDtoContentHash := versionContentHash(versionSpecDto, &resp.Diagnostics)
+		versionSpecDtoContentHash := calculateBuildingBlockDefinitionVersionContentHash(versionSpecDto, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if versionSpecDtoContentHash == state.VersionLatest.ContentHash.Get() {
-			// display_order is excluded from the content hash, so an equal hash could still mean changed display_order.
-			// Released versions are immutable, so reject a display_order-only change explicitly
-			if displayOrdersDiffer(plan.VersionSpec.MeshBuildingBlockDefinitionVersionSpec, state.VersionSpec.MeshBuildingBlockDefinitionVersionSpec) {
-				resp.Diagnostics.AddError("Error updating version_spec", fmt.Sprintf(
-					"Changing display_order on a released version %d is not allowed — released versions are immutable.",
-					state.VersionLatest.Number.Get(),
-				))
-				return
-			}
-			// state is in draft=false (aka released), and there's no change in version_spec,
+		if !versionSpecDtoContentHash.indicatesChangesTowardsHash(state.VersionLatest.ContentHash.Get()) {
+			// state is in draft=false (aka released), and there's no indication of change in version_specs,
 			// so all is good, and we don't need to do anything with the backend
 			return
 		} else {
@@ -534,7 +504,7 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 					"To publish your changes as a new version, first set draft = true and apply to create a draft. "+
 					"Once you are happy with the draft, set draft = false and apply again to release it.\n\n"+
 					"(The content hash would change from %s to %s.)",
-				state.VersionLatest.ContentHash.Get(), versionSpecDtoContentHash,
+				state.VersionLatest.ContentHash.Get(), versionSpecDtoContentHash.toBase64(),
 			))
 			return
 		}
@@ -563,15 +533,15 @@ func (r *buildingBlockDefinitionResource) Update(ctx context.Context, req resour
 		return
 	}
 	if updatedVersionDto != nil {
-		updatedVersionSpecContentHash := versionContentHash(updatedVersionDto.Spec, &resp.Diagnostics)
+		updatedVersionSpecContentHash := calculateBuildingBlockDefinitionVersionContentHash(updatedVersionDto.Spec, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if plan.VersionLatest.ContentHash.Get() != updatedVersionSpecContentHash {
+		if updatedVersionSpecContentHash.indicatesChangesTowardsHash(plan.VersionLatest.ContentHash.Get()) {
 			resp.Diagnostics.AddError("Inconsistent content hash of version_spec after update", fmt.Sprintf(
 				"The content hash of the latest version after listing does not match the content hash of the updated/created response: %s != %s. "+
 					"This is most likely a bug in the backend.",
-				plan.VersionLatest.ContentHash.Get(), updatedVersionSpecContentHash,
+				plan.VersionLatest.ContentHash.Get(), updatedVersionSpecContentHash.toBase64(),
 			))
 			return
 		}

--- a/internal/provider/building_block_definition_resource_model.go
+++ b/internal/provider/building_block_definition_resource_model.go
@@ -1,10 +1,8 @@
 package provider
 
 import (
-	"bytes"
 	"cmp"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -18,7 +16,6 @@ import (
 	clientTypes "github.com/meshcloud/terraform-provider-meshstack/client/types"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/generic"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/secret"
-	"github.com/meshcloud/terraform-provider-meshstack/internal/util/hash"
 	reflectwalk "github.com/meshcloud/terraform-provider-meshstack/internal/util/reflect"
 )
 
@@ -259,7 +256,7 @@ func (model *buildingBlockDefinition) SetFromVersionClientDtos(diags *diag.Diagn
 			Uuid:        generic.KnownValue(versionDto.Metadata.Uuid),
 			Number:      generic.KnownValue(*versionDto.Spec.VersionNumber),
 			State:       generic.KnownValue(*versionDto.Spec.State),
-			ContentHash: generic.KnownValue(versionContentHash(versionDto.Spec, diags)),
+			ContentHash: generic.KnownValue(calculateBuildingBlockDefinitionVersionContentHash(versionDto.Spec, diags).toBase64()),
 		}
 	}
 	if diags.HasError() {
@@ -307,66 +304,6 @@ func (model *buildingBlockDefinition) SetFromVersionClientDtos(diags *diag.Diagn
 	}
 
 	model.Ref = newBuildingBlockDefinitionRef(bbdUuid)
-}
-
-func versionContentHash(versionSpecDto client.MeshBuildingBlockDefinitionVersionSpec, diags *diag.Diagnostics) string {
-	if result, err := func() (string, error) {
-		// Safeguard against accidentally hashing plaintext secret values (the backend only ever returns
-		// hashes, so plaintext would make the hash unstable). Detection is on the typed DTO so user data -
-		// e.g. an input named "plaintext" or a STATIC argument whose JSON carries a "plaintext" key - is
-		// never mistaken for a secret. Callers leave the hash unknown when a secret rotates (issue #196).
-		if versionSpecContainsPlaintextSecret(versionSpecDto) {
-			return "", errors.New("version_spec carries a plaintext secret value, which must not be hashed")
-		}
-
-		// Ignore version, state, and buildingBlockDefinitionRef fields by setting them to constant values, always!
-		versionSpecDto.VersionNumber = nil
-		versionSpecDto.State = nil
-		versionSpecDto.BuildingBlockDefinitionRef = nil
-
-		// display_order is presentation-only so create a copy without it
-		strippedInputs := make(map[string]*client.MeshBuildingBlockDefinitionInput, len(versionSpecDto.Inputs))
-		for key, input := range versionSpecDto.Inputs {
-			clone := *input
-			clone.DisplayOrder = 0
-			strippedInputs[key] = &clone
-		}
-		versionSpecDto.Inputs = strippedInputs
-
-		strippedOutputs := make(map[string]client.MeshBuildingBlockDefinitionOutput, len(versionSpecDto.Outputs))
-		for key, output := range versionSpecDto.Outputs {
-			output.DisplayOrder = 0
-			strippedOutputs[key] = output
-		}
-		versionSpecDto.Outputs = strippedOutputs
-
-		// Converting it first from/to JSON makes hashing more stable, as fields with 'omitempty' are ignored.
-		// Additionally, all numbers are converted to float64, even integers (which also allows changing DTO model types later on).
-		// Also, the current Hasher implementation does not support structs for now, but map[string]any works!
-		var buffer bytes.Buffer
-		if err := json.NewEncoder(&buffer).Encode(versionSpecDto); err != nil {
-			return "", err
-		}
-		var converted any
-		if err := json.NewDecoder(&buffer).Decode(&converted); err != nil {
-			return "", err
-		}
-
-		versionSpecHash, err := hash.Hasher{}.Hash(converted)
-		if err != nil {
-			return "", err
-		}
-		// add some versioning prefix to migrate possible changes in the hashes later on,
-		// but let's hope migrating/fixing the hashes is never required
-		return "v1:" + versionSpecHash.Hex(), nil
-	}(); err != nil {
-		diags.AddError("Failed to determine content hash", fmt.Sprintf(
-			"Content hashing of version_spec as client DTO failed: %s", err.Error(),
-		))
-		return ""
-	} else {
-		return result
-	}
 }
 
 // versionSpecContainsPlaintextSecret reports whether the typed version_spec DTO carries a secret whose

--- a/internal/provider/building_block_definition_resource_model.go
+++ b/internal/provider/building_block_definition_resource_model.go
@@ -324,6 +324,22 @@ func versionContentHash(versionSpecDto client.MeshBuildingBlockDefinitionVersion
 		versionSpecDto.State = nil
 		versionSpecDto.BuildingBlockDefinitionRef = nil
 
+		// display_order is presentation-only so create a copy without it
+		strippedInputs := make(map[string]*client.MeshBuildingBlockDefinitionInput, len(versionSpecDto.Inputs))
+		for key, input := range versionSpecDto.Inputs {
+			clone := *input
+			clone.DisplayOrder = 0
+			strippedInputs[key] = &clone
+		}
+		versionSpecDto.Inputs = strippedInputs
+
+		strippedOutputs := make(map[string]client.MeshBuildingBlockDefinitionOutput, len(versionSpecDto.Outputs))
+		for key, output := range versionSpecDto.Outputs {
+			output.DisplayOrder = 0
+			strippedOutputs[key] = output
+		}
+		versionSpecDto.Outputs = strippedOutputs
+
 		// Converting it first from/to JSON makes hashing more stable, as fields with 'omitempty' are ignored.
 		// Additionally, all numbers are converted to float64, even integers (which also allows changing DTO model types later on).
 		// Also, the current Hasher implementation does not support structs for now, but map[string]any works!

--- a/internal/provider/building_block_definition_resource_model_test.go
+++ b/internal/provider/building_block_definition_resource_model_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
@@ -56,61 +55,4 @@ func Test_versionContentHash(t *testing.T) {
 			require.Equal(t, tt.want, actualHashStr)
 		})
 	}
-}
-
-func Test_versionContentHash_plaintextSecret(t *testing.T) {
-	var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
-	require.NoError(t, json.Unmarshal(versionSpecPlaintextSecretJson, &versionSpec))
-	var diags diag.Diagnostics
-	calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags)
-	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Detail(), "version_spec carries a plaintext secret value, which must not be hashed")
-}
-
-// Test_versionContentHash_userDataNamedPlaintext guards against the false positive from issue #196: an
-// input named "plaintext" is a user-chosen map key, not a secret, so it must hash successfully rather than
-// trip the plaintext safeguard (the old JSON-key-based safeguard rejected it).
-func Test_versionContentHash_userDataNamedPlaintext(t *testing.T) {
-	const userDataJson = `{
-		"inputs": {
-			"plaintext": {
-				"displayName": "Plaintext",
-				"type": "STRING",
-				"assignmentType": "STATIC",
-				"argument": "hello"
-			}
-		},
-		"implementation": {"terraform": {}}
-	}`
-	var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
-	require.NoError(t, json.Unmarshal([]byte(userDataJson), &versionSpec))
-	var diags diag.Diagnostics
-	actualHashStr := calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags).toBase64()
-	require.Empty(t, diags)
-	assert.NotEmpty(t, actualHashStr)
-}
-
-// Test_versionContentHash_ignoresPerVersionFields pins the invariant that the content hash is independent
-// of the per-BBD buildingBlockDefinitionRef and the per-version versionNumber/state (all stripped before
-// hashing). Were they hashed, the same version_spec would hash differently across BBDs/versions, breaking
-// the released-version immutability and change-detection comparisons. This is the focused, behavioral
-// replacement for the old DisallowMapKeys("buildingBlockDefinitionRef") safeguard, which - like the
-// "plaintext" one - would have misfired on a user-chosen input/output named "buildingBlockDefinitionRef".
-func Test_versionContentHash_ignoresPerVersionFields(t *testing.T) {
-	var base, mutated client.MeshBuildingBlockDefinitionVersionSpec
-	require.NoError(t, json.Unmarshal(versionSpecJson, &base))
-	require.NoError(t, json.Unmarshal(versionSpecJson, &mutated))
-
-	mutated.BuildingBlockDefinitionRef = &client.BuildingBlockDefinitionRef{
-		Kind: client.MeshObjectKind.BuildingBlockDefinition,
-		Uuid: "a-different-bbd-uuid",
-	}
-	mutated.VersionNumber = new(int64(99))
-	mutated.State = client.MeshBuildingBlockDefinitionVersionStateReleased.Ptr()
-
-	var diags diag.Diagnostics
-	baseHash := calculateBuildingBlockDefinitionVersionContentHash(base, &diags).toBase64()
-	mutatedHash := calculateBuildingBlockDefinitionVersionContentHash(mutated, &diags).toBase64()
-	require.Empty(t, diags)
-	assert.Equal(t, baseHash, mutatedHash, "buildingBlockDefinitionRef/versionNumber/state must not affect the content hash")
 }

--- a/internal/provider/building_block_definition_resource_model_test.go
+++ b/internal/provider/building_block_definition_resource_model_test.go
@@ -114,3 +114,25 @@ func Test_versionContentHash_ignoresPerVersionFields(t *testing.T) {
 	require.Empty(t, diags)
 	assert.Equal(t, baseHash, mutatedHash, "buildingBlockDefinitionRef/versionNumber/state must not affect the content hash")
 }
+
+func Test_versionContentHash_ignoresDisplayOrder(t *testing.T) {
+	var base, mutated client.MeshBuildingBlockDefinitionVersionSpec
+	require.NoError(t, json.Unmarshal(versionSpecJson, &base))
+	require.NoError(t, json.Unmarshal(versionSpecJson, &mutated))
+
+	require.NotEmpty(t, mutated.Inputs, "test fixture must contain at least one input")
+	for _, input := range mutated.Inputs {
+		input.DisplayOrder = 7
+	}
+	require.NotEmpty(t, mutated.Outputs, "test fixture must contain at least one output")
+	for key, output := range mutated.Outputs {
+		output.DisplayOrder = 11
+		mutated.Outputs[key] = output
+	}
+
+	var diags diag.Diagnostics
+	baseHash := versionContentHash(base, &diags)
+	mutatedHash := versionContentHash(mutated, &diags)
+	require.Empty(t, diags)
+	assert.Equal(t, baseHash, mutatedHash, "display_order must not affect the content hash")
+}

--- a/internal/provider/building_block_definition_resource_model_test.go
+++ b/internal/provider/building_block_definition_resource_model_test.go
@@ -30,9 +30,9 @@ var (
 func Test_versionContentHash(t *testing.T) {
 	// If constant values below are required to change, you need a good reason and consider backwards compatibility!
 	const (
-		hashWhichShouldNeverChange1 = "v1:674c77c28e4eb4cec99b9f1e73ad11b520a367da416ff3fa90d5e5426e09befc"
-		hashWhichShouldNeverChange2 = "v1:020cd7c032ff6ce05a02873fd319e7b7206896fa415904791836c933f0a239ee"
-		hashWhichShouldNeverChange3 = "v1:2b992e234316baa08d1f4d017f57379ddfb45f39f3ae7b148079322938dfd8e0"
+		hashWhichShouldNeverChange1 = "djI6Njc0Yzc3YzI4ZTRlYjRjZWM5OWI5ZjFlNzNhZDExYjUyMGEzNjdkYTQxNmZmM2ZhOTBkNWU1NDI2ZTA5YmVmYw=="
+		hashWhichShouldNeverChange2 = "djI6MDIwY2Q3YzAzMmZmNmNlMDVhMDI4NzNmZDMxOWU3YjcyMDY4OTZmYTQxNTkwNDc5MTgzNmM5MzNmMGEyMzllZQ=="
+		hashWhichShouldNeverChange3 = "djI6MmI5OTJlMjM0MzE2YmFhMDhkMWY0ZDAxN2Y1NzM3OWRkZmI0NWYzOWYzYWU3YjE0ODA3OTMyMjkzOGRmZDhlMA=="
 	)
 	require.NotEqual(t, hashWhichShouldNeverChange1, hashWhichShouldNeverChange2)
 	tests := []struct {
@@ -51,9 +51,9 @@ func Test_versionContentHash(t *testing.T) {
 			var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
 			require.NoError(t, json.Unmarshal(tt.json, &versionSpec))
 			var diags diag.Diagnostics
-			actualHash := versionContentHash(versionSpec, &diags)
+			actualHashStr := calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags).toBase64()
 			require.Empty(t, diags)
-			require.Equal(t, tt.want, actualHash)
+			require.Equal(t, tt.want, actualHashStr)
 		})
 	}
 }
@@ -62,7 +62,7 @@ func Test_versionContentHash_plaintextSecret(t *testing.T) {
 	var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
 	require.NoError(t, json.Unmarshal(versionSpecPlaintextSecretJson, &versionSpec))
 	var diags diag.Diagnostics
-	versionContentHash(versionSpec, &diags)
+	calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags)
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Detail(), "version_spec carries a plaintext secret value, which must not be hashed")
 }
@@ -85,9 +85,9 @@ func Test_versionContentHash_userDataNamedPlaintext(t *testing.T) {
 	var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
 	require.NoError(t, json.Unmarshal([]byte(userDataJson), &versionSpec))
 	var diags diag.Diagnostics
-	actualHash := versionContentHash(versionSpec, &diags)
+	actualHashStr := calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags).toBase64()
 	require.Empty(t, diags)
-	assert.NotEmpty(t, actualHash)
+	assert.NotEmpty(t, actualHashStr)
 }
 
 // Test_versionContentHash_ignoresPerVersionFields pins the invariant that the content hash is independent
@@ -109,30 +109,8 @@ func Test_versionContentHash_ignoresPerVersionFields(t *testing.T) {
 	mutated.State = client.MeshBuildingBlockDefinitionVersionStateReleased.Ptr()
 
 	var diags diag.Diagnostics
-	baseHash := versionContentHash(base, &diags)
-	mutatedHash := versionContentHash(mutated, &diags)
+	baseHash := calculateBuildingBlockDefinitionVersionContentHash(base, &diags).toBase64()
+	mutatedHash := calculateBuildingBlockDefinitionVersionContentHash(mutated, &diags).toBase64()
 	require.Empty(t, diags)
 	assert.Equal(t, baseHash, mutatedHash, "buildingBlockDefinitionRef/versionNumber/state must not affect the content hash")
-}
-
-func Test_versionContentHash_ignoresDisplayOrder(t *testing.T) {
-	var base, mutated client.MeshBuildingBlockDefinitionVersionSpec
-	require.NoError(t, json.Unmarshal(versionSpecJson, &base))
-	require.NoError(t, json.Unmarshal(versionSpecJson, &mutated))
-
-	require.NotEmpty(t, mutated.Inputs, "test fixture must contain at least one input")
-	for _, input := range mutated.Inputs {
-		input.DisplayOrder = 7
-	}
-	require.NotEmpty(t, mutated.Outputs, "test fixture must contain at least one output")
-	for key, output := range mutated.Outputs {
-		output.DisplayOrder = 11
-		mutated.Outputs[key] = output
-	}
-
-	var diags diag.Diagnostics
-	baseHash := versionContentHash(base, &diags)
-	mutatedHash := versionContentHash(mutated, &diags)
-	require.Empty(t, diags)
-	assert.Equal(t, baseHash, mutatedHash, "display_order must not affect the content hash")
 }

--- a/internal/provider/building_block_definition_resource_schema.go
+++ b/internal/provider/building_block_definition_resource_schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
@@ -157,6 +158,13 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 					MarkdownDescription: "Error message to display when regex validation fails.",
 					Optional:            true,
 				},
+				"display_order": schema.Int64Attribute{
+					MarkdownDescription: "Numeric value controlling the display ordering of this input in meshPanel. " +
+						"Used only for arranging inputs; it does not affect the version's content hash. Defaults to `0` when omitted.",
+					Optional: true,
+					Computed: true,
+					Default:  int64default.StaticInt64(0),
+				},
 			},
 		},
 	}
@@ -184,6 +192,13 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 			Validators: []validator.String{
 				stringvalidator.OneOf(client.MeshBuildingBlockOutputIOTypes.Strings()...),
 			},
+		},
+		"display_order": schema.Int64Attribute{
+			MarkdownDescription: "Numeric value controlling the display ordering of this output in meshPanel. " +
+				"Used only for arranging outputs; it does not affect the version's content hash. Defaults to `0` when omitted.",
+			Optional: true,
+			Computed: true,
+			Default:  int64default.StaticInt64(0),
 		},
 	},
 	}

--- a/internal/provider/building_block_definition_resource_schema.go
+++ b/internal/provider/building_block_definition_resource_schema.go
@@ -159,8 +159,8 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 					Optional:            true,
 				},
 				"display_order": schema.Int64Attribute{
-					MarkdownDescription: "Numeric value controlling the display ordering of this input in meshPanel. " +
-						"Used only for arranging inputs; it does not affect the version's content hash. Defaults to `0` when omitted.",
+					MarkdownDescription: "Numeric value controlling in which order the inputs are displayed in the UI. " +
+						"Cannot be changed on a released version. When omitted, uses existing value, if any. Otherwise defaults to `0`.",
 					Optional: true,
 					Computed: true,
 					Default:  int64default.StaticInt64(0),
@@ -194,8 +194,8 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 			},
 		},
 		"display_order": schema.Int64Attribute{
-			MarkdownDescription: "Numeric value controlling the display ordering of this output in meshPanel. " +
-				"Used only for arranging outputs; it does not affect the version's content hash. Defaults to `0` when omitted.",
+			MarkdownDescription: "Numeric value controlling in which order the outputs are displayed in the UI. " +
+				"Cannot be changed on a released version. When omitted, uses existing value, if any. Otherwise defaults to `0`.",
 			Optional: true,
 			Computed: true,
 			Default:  int64default.StaticInt64(0),

--- a/internal/provider/building_block_definition_resource_test.go
+++ b/internal/provider/building_block_definition_resource_test.go
@@ -430,6 +430,7 @@ func TestAccBuildingBlockDefinition(t *testing.T) {
 				"display_name":    knownvalue.StringExact(displayName),
 				"type":            knownvalue.StringExact(ioType),
 				"assignment_type": knownvalue.StringExact("NONE"),
+				"display_order":   knownvalue.Int64Exact(0),
 			})
 		}
 		baseOutputs := knownvalue.MapExact(map[string]knownvalue.Check{
@@ -820,6 +821,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(1),
 				}),
 				"resource_name": xknownvalue.MapExact(map[string]knownvalue.Check{
 					"display_name":                   knownvalue.StringExact("Resource Name"),
@@ -834,6 +836,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"validation_regex_error_message": knownvalue.StringExact("Resource name must contain only lowercase letters, numbers, and hyphens"),
 					"selectable_values":              knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(2),
 				}),
 				"SOMETHING_VERY_SECRET": xknownvalue.MapExact(map[string]knownvalue.Check{
 					"display_name":           knownvalue.StringExact("Top Secret"),
@@ -855,6 +858,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"selectable_values":              knownvalue.Null(),
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(0),
 				}),
 				"some-file.yaml": xknownvalue.MapExact(map[string]knownvalue.Check{
 					"display_name":                   knownvalue.StringExact("Some input file"),
@@ -869,6 +873,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"validation_regex_error_message": knownvalue.Null(),
 					"selectable_values":              knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(0),
 				}),
 			}),
 			xknownvalue.MapExact(map[string]knownvalue.Check{
@@ -882,11 +887,13 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"display_name":    knownvalue.StringExact("If true, it really worked"),
 					"type":            knownvalue.StringExact("BOOLEAN"),
 					"assignment_type": knownvalue.StringExact("NONE"),
+					"display_order":   knownvalue.Int64Exact(1),
 				}),
 				"summary": xknownvalue.MapExact(map[string]knownvalue.Check{
 					"display_name":    knownvalue.StringExact("Summary of work"),
 					"type":            knownvalue.StringExact("STRING"),
 					"assignment_type": knownvalue.StringExact("SUMMARY"),
+					"display_order":   knownvalue.Int64Exact(2),
 				}),
 			})
 	case "02_github_workflows":
@@ -904,6 +911,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(0),
 				}),
 			}),
 			xknownvalue.MapExact(map[string]knownvalue.Check{
@@ -918,6 +926,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"display_name":    knownvalue.StringExact("Workflow Run URL"),
 					"type":            knownvalue.StringExact("STRING"),
 					"assignment_type": knownvalue.StringExact("RESOURCE_URL"),
+					"display_order":   knownvalue.Int64Exact(0),
 				}),
 			})
 	case "03_manual":
@@ -935,6 +944,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(0),
 				}),
 			}),
 			xknownvalue.MapExact(map[string]knownvalue.Check{
@@ -949,6 +959,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"display_name":    knownvalue.StringExact("Approval Required"),
 					"type":            knownvalue.StringExact("BOOLEAN"),
 					"assignment_type": knownvalue.StringExact("NONE"),
+					"display_order":   knownvalue.Int64Exact(0),
 				}),
 			})
 	case "04_azure_devops_pipeline":
@@ -966,6 +977,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(0),
 				}),
 			}),
 			xknownvalue.MapExact(map[string]knownvalue.Check{
@@ -980,6 +992,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"display_name":    knownvalue.StringExact("Pipeline Run ID"),
 					"type":            knownvalue.StringExact("STRING"),
 					"assignment_type": knownvalue.StringExact("NONE"),
+					"display_order":   knownvalue.Int64Exact(0),
 				}),
 			})
 	case "05_gitlab_pipeline":
@@ -997,6 +1010,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.Null(),
 					"sensitive":                      knownvalue.Null(),
+					"display_order":                  knownvalue.Int64Exact(0),
 				}),
 			}),
 			xknownvalue.MapExact(map[string]knownvalue.Check{
@@ -1011,6 +1025,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"display_name":    knownvalue.StringExact("Pipeline URL"),
 					"type":            knownvalue.StringExact("STRING"),
 					"assignment_type": knownvalue.StringExact("RESOURCE_URL"),
+					"display_order":   knownvalue.Int64Exact(0),
 				}),
 			})
 	default:

--- a/internal/provider/building_block_definition_version_content_hash.go
+++ b/internal/provider/building_block_definition_version_content_hash.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -15,19 +16,27 @@ import (
 )
 
 const (
-	errorHashVersion   = "err"
-	currentHashVersion = "v2"
+	currentHashVersion = 2
 )
 
 // represents a content hash of a building block definition version, which is used to detect changes in the version_spec.
-// because the version_spec is subject to change w.r.t. new fields etc., the hash is versioned
-// this means we can only meaningfully compare hashes of the same version
-// use func indicatesChangesTowardsHash(hashStr string) to detect whether an instance of BuildingBlockDefinitionVersionContentHash
-// differs from a previously calculated hash string representation.
+// because the version_spec is subject to change w.r.t. new fields etc., the hash is versioned.
 type BuildingBlockDefinitionVersionContentHash struct {
-	hashVersion string
+	hashVersion int
 	hashValue   string
 }
+
+// hashComparison is the three-way result of comparing a freshly computed content hash against a
+// previously stored one. Two hash *values* are only meaningful to compare when they were produced
+// by the same hash version (algorithm); across versions the values are unrelated, so the outcome is
+// hashIncomparable.
+type hashComparison int
+
+const (
+	hashIncomparable hashComparison = iota
+	hashSame
+	hashDifferent
+)
 
 func calculateBuildingBlockDefinitionVersionContentHash(versionSpecDto client.MeshBuildingBlockDefinitionVersionSpec, diags *diag.Diagnostics) BuildingBlockDefinitionVersionContentHash {
 	if result, err := func() (string, error) {
@@ -70,7 +79,7 @@ func calculateBuildingBlockDefinitionVersionContentHash(versionSpecDto client.Me
 			"Content hashing of version_spec as client DTO failed: %s", err.Error(),
 		))
 
-		return errorHash()
+		return BuildingBlockDefinitionVersionContentHash{}
 	} else {
 
 		return BuildingBlockDefinitionVersionContentHash{
@@ -80,57 +89,63 @@ func calculateBuildingBlockDefinitionVersionContentHash(versionSpecDto client.Me
 	}
 }
 
-// we can only safely know that two definition versions differ in case they have both the same hash version
-// and different hash values. If the hash versions differ, we cannot know whether the content has changed or not.
-func (h BuildingBlockDefinitionVersionContentHash) indicatesChangesTowardsHash(hashStr string) bool {
+func getVersionedHashFromString(encoded string) (BuildingBlockDefinitionVersionContentHash, error) {
+	// v1 hashes were just simple strings in the format of "v1:<hash>"
+	// later version representations are all base64 encoded strings
+	if strings.HasPrefix(encoded, "v1:") { // safe check, as base64 cannot contain ":"
+		return BuildingBlockDefinitionVersionContentHash{
+			hashVersion: 1,
+			hashValue:   encoded,
+		}, nil
+	} else {
+		h := BuildingBlockDefinitionVersionContentHash{}
+		err := h.loadFromBase64(encoded)
+		return h, err
+	}
+}
 
-	getVersionedHashFromString := func(encoded string) BuildingBlockDefinitionVersionContentHash {
-		// v1 hashes were just simple strings in the format of "v1:<hash>"
-		// later version representations are all base64 encoded strings
-		if strings.HasPrefix(encoded, "v1:") { // safe check, as base64 cannot contain ":"
-			return BuildingBlockDefinitionVersionContentHash{
-				hashVersion: "v1",
-				hashValue:   encoded,
-			}
-		} else {
-			h := BuildingBlockDefinitionVersionContentHash{}
-			h.loadFromBase64(encoded)
-			return h
-		}
+// compareToStored compares the receiver (always freshly computed at currentHashVersion) against a
+// previously stored hash string. It returns hashIncomparable when the hash versions differ or either
+// side is an error/unparsable hash — callers MUST treat that as "unknown", never as "no change".
+func (h BuildingBlockDefinitionVersionContentHash) compareToStored(storedStr string) hashComparison {
+	other, err := getVersionedHashFromString(storedStr)
+
+	if err != nil || h.hashVersion != other.hashVersion {
+		return hashIncomparable
 	}
 
-	other := getVersionedHashFromString(hashStr)
+	if h.hashValue == other.hashValue {
+		return hashSame
+	}
 
-	return (h.hashVersion == other.hashVersion) && (h.hashValue != other.hashValue)
+	return hashDifferent
 }
 
 func (h BuildingBlockDefinitionVersionContentHash) toBase64() string {
-	text := h.hashVersion + ":" + h.hashValue
+	text := fmt.Sprintf("v%d:%s", h.hashVersion, h.hashValue)
 	encoded := base64.StdEncoding.EncodeToString([]byte(text))
 
 	return encoded
 }
 
-func (h *BuildingBlockDefinitionVersionContentHash) loadFromBase64(encoded string) {
+func (h *BuildingBlockDefinitionVersionContentHash) loadFromBase64(encoded string) error {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		h.hashVersion = errorHashVersion
-		return
+		return err
 	}
 
 	parts := strings.Split(string(decoded), ":")
 	if len(parts) != 2 {
-		h.hashVersion = errorHashVersion
-		return
+		return errors.New("invalid hash format: expected 'version:value'")
 	}
 
-	h.hashVersion = parts[0]
+	hashVersion, err := strconv.Atoi(parts[0][1:]) // skip leading "v"
+	if err != nil {
+		return errors.New("invalid hash version: expected integer")
+	}
+
+	h.hashVersion = hashVersion
 	h.hashValue = parts[1]
-}
 
-func errorHash() BuildingBlockDefinitionVersionContentHash {
-	return BuildingBlockDefinitionVersionContentHash{
-		hashVersion: errorHashVersion,
-		hashValue:   "",
-	}
+	return nil
 }

--- a/internal/provider/building_block_definition_version_content_hash.go
+++ b/internal/provider/building_block_definition_version_content_hash.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+
+	"github.com/meshcloud/terraform-provider-meshstack/client"
+	"github.com/meshcloud/terraform-provider-meshstack/internal/util/hash"
+)
+
+const (
+	errorHashVersion   = "err"
+	currentHashVersion = "v2"
+)
+
+// represents a content hash of a building block definition version, which is used to detect changes in the version_spec.
+// because the version_spec is subject to change w.r.t. new fields etc., the hash is versioned
+// this means we can only meaningfully compare hashes of the same version
+// use func indicatesChangesTowardsHash(hashStr string) to detect whether an instance of BuildingBlockDefinitionVersionContentHash
+// differs from a previously calculated hash string representation.
+type BuildingBlockDefinitionVersionContentHash struct {
+	hashVersion string
+	hashValue   string
+}
+
+func calculateBuildingBlockDefinitionVersionContentHash(versionSpecDto client.MeshBuildingBlockDefinitionVersionSpec, diags *diag.Diagnostics) BuildingBlockDefinitionVersionContentHash {
+	if result, err := func() (string, error) {
+		// Safeguard against accidentally hashing plaintext secret values (the backend only ever returns
+		// hashes, so plaintext would make the hash unstable). Detection is on the typed DTO so user data -
+		// e.g. an input named "plaintext" or a STATIC argument whose JSON carries a "plaintext" key - is
+		// never mistaken for a secret. Callers leave the hash unknown when a secret rotates (issue #196).
+		if versionSpecContainsPlaintextSecret(versionSpecDto) {
+			return "", errors.New("version_spec carries a plaintext secret value, which must not be hashed")
+		}
+
+		// Ignore version, state, and buildingBlockDefinitionRef fields by setting them to constant values, always!
+		versionSpecDto.VersionNumber = nil
+		versionSpecDto.State = nil
+		versionSpecDto.BuildingBlockDefinitionRef = nil
+
+		// Converting it first from/to JSON makes hashing more stable, as fields with 'omitempty' are ignored.
+		// Additionally, all numbers are converted to float64, even integers (which also allows changing DTO model types later on).
+		// Also, the current Hasher implementation does not support structs for now, but map[string]any works!
+		var buffer bytes.Buffer
+		if err := json.NewEncoder(&buffer).Encode(versionSpecDto); err != nil {
+			return "", err
+		}
+		var converted any
+		if err := json.NewDecoder(&buffer).Decode(&converted); err != nil {
+			return "", err
+		}
+
+		versionSpecHash, err := hash.Hasher{}.Hash(converted)
+		if err != nil {
+			return "", err
+		}
+
+		// add some versioning prefix to migrate possible changes in the hashes later on,
+		// but let's hope migrating/fixing the hashes is never required
+		return versionSpecHash.Hex(), nil
+
+	}(); err != nil {
+		diags.AddError("Failed to determine content hash", fmt.Sprintf(
+			"Content hashing of version_spec as client DTO failed: %s", err.Error(),
+		))
+
+		return errorHash()
+	} else {
+
+		return BuildingBlockDefinitionVersionContentHash{
+			hashVersion: currentHashVersion,
+			hashValue:   result,
+		}
+	}
+}
+
+// we can only safely know that two definition versions differ in case they have both the same hash version
+// and different hash values. If the hash versions differ, we cannot know whether the content has changed or not.
+func (h BuildingBlockDefinitionVersionContentHash) indicatesChangesTowardsHash(hashStr string) bool {
+
+	getVersionedHashFromString := func(encoded string) BuildingBlockDefinitionVersionContentHash {
+		// v1 hashes were just simple strings in the format of "v1:<hash>"
+		// later version representations are all base64 encoded strings
+		if strings.HasPrefix(encoded, "v1:") { // safe check, as base64 cannot contain ":"
+			return BuildingBlockDefinitionVersionContentHash{
+				hashVersion: "v1",
+				hashValue:   encoded,
+			}
+		} else {
+			h := BuildingBlockDefinitionVersionContentHash{}
+			h.loadFromBase64(encoded)
+			return h
+		}
+	}
+
+	other := getVersionedHashFromString(hashStr)
+
+	return (h.hashVersion == other.hashVersion) && (h.hashValue != other.hashValue)
+}
+
+func (h BuildingBlockDefinitionVersionContentHash) toBase64() string {
+	text := h.hashVersion + ":" + h.hashValue
+	encoded := base64.StdEncoding.EncodeToString([]byte(text))
+
+	return encoded
+}
+
+func (h *BuildingBlockDefinitionVersionContentHash) loadFromBase64(encoded string) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		h.hashVersion = errorHashVersion
+		return
+	}
+
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 2 {
+		h.hashVersion = errorHashVersion
+		return
+	}
+
+	h.hashVersion = parts[0]
+	h.hashValue = parts[1]
+}
+
+func errorHash() BuildingBlockDefinitionVersionContentHash {
+	return BuildingBlockDefinitionVersionContentHash{
+		hashVersion: errorHashVersion,
+		hashValue:   "",
+	}
+}

--- a/internal/provider/building_block_definition_version_content_hash.go
+++ b/internal/provider/building_block_definition_version_content_hash.go
@@ -104,9 +104,6 @@ func getVersionedHashFromString(encoded string) (BuildingBlockDefinitionVersionC
 	}
 }
 
-// compareToStored compares the receiver (always freshly computed at currentHashVersion) against a
-// previously stored hash string. It returns hashIncomparable when the hash versions differ or either
-// side is an error/unparsable hash — callers MUST treat that as "unknown", never as "no change".
 func (h BuildingBlockDefinitionVersionContentHash) compareToStored(storedStr string) hashComparison {
 	other, err := getVersionedHashFromString(storedStr)
 

--- a/internal/provider/building_block_definition_version_content_hash_test.go
+++ b/internal/provider/building_block_definition_version_content_hash_test.go
@@ -83,11 +83,10 @@ func Test_contentHash_changeDetectionEndToEnd(t *testing.T) {
 	assert.Equal(t, hashDifferent, relevant.compareToStored(stored))
 }
 
-// Mirrors the released-version immutability guard's fail-safe: when the stored hash is from a legacy /
-// unknown algorithm version (e.g. written by an older provider and never refreshed), it is incomparable
-// to the current-version hash. The guard then recomputes the released spec from state AT THE CURRENT
-// version so the comparison becomes meaningful again — a genuine change is detected (would reject) and
-// an unchanged spec is recognized (no-op), instead of the old silent "no change" guess.
+// Mirrors the released-version immutability guard's fail-safe: when the stored hash is from an older provider,
+// it is incomparable to the current-version hash.
+// The guard then recomputes the released spec from state AT THE CURRENT version so the comparison becomes
+// meaningful again — a genuine change is detected (would reject) and an unchanged spec is recognized (no-op).
 func Test_contentHash_incomparableStoredHash_resolvedByRecomputeAtCurrentVersion(t *testing.T) {
 	changedPlanHash := forTestCalculateContentHash(t, versionSpecRelevantChangeJson)
 	unchangedPlanHash := forTestCalculateContentHash(t, versionSpecJson)

--- a/internal/provider/building_block_definition_version_content_hash_test.go
+++ b/internal/provider/building_block_definition_version_content_hash_test.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meshcloud/terraform-provider-meshstack/client"
+)
+
+func Test_contentHash_base64Roundtrip(t *testing.T) {
+	original := BuildingBlockDefinitionVersionContentHash{hashVersion: currentHashVersion, hashValue: "foobar"}
+
+	var decoded BuildingBlockDefinitionVersionContentHash
+	require.NoError(t, decoded.loadFromBase64(original.toBase64()))
+
+	assert.Equal(t, original, decoded)
+}
+
+func Test_contentHash_loadFromBase64_malformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded string
+	}{
+		{"not base64", "this is not base64 !!!"},
+		{"base64 without colon", base64.StdEncoding.EncodeToString([]byte("noColonHere"))},
+		{"base64 with too many colons", base64.StdEncoding.EncodeToString([]byte("v2:v3:bbb"))},
+		{"base64 with non-integer version", base64.StdEncoding.EncodeToString([]byte("vX:bbb"))},
+		{"empty string", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := BuildingBlockDefinitionVersionContentHash{hashVersion: currentHashVersion, hashValue: "seed"}
+			assert.Error(t, h.loadFromBase64(tt.encoded))
+		})
+	}
+}
+
+func Test_contentHash_compareToStored(t *testing.T) {
+	hash1 := BuildingBlockDefinitionVersionContentHash{hashVersion: 2, hashValue: "aaa"}
+	hash2 := BuildingBlockDefinitionVersionContentHash{hashVersion: 2, hashValue: "bbb"}
+
+	tests := []struct {
+		name    string
+		current BuildingBlockDefinitionVersionContentHash
+		stored  string
+		want    hashComparison
+	}{
+		{"same version, same value -> same", hash1, hash1.toBase64(), hashSame},
+		{"same version, different value -> different", hash1, hash2.toBase64(), hashDifferent},
+		{"stored v1 raw, current v2 -> incomparable", hash1, "v1:someOldHash", hashIncomparable},
+		{"stored unparsable -> incomparable", hash1, "not base64 !!!", hashIncomparable},
+		{"stored empty -> incomparable", hash1, "", hashIncomparable},
+		{"unparsable receiver -> incomparable", BuildingBlockDefinitionVersionContentHash{}, hash1.toBase64(), hashIncomparable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.current.compareToStored(tt.stored))
+		})
+	}
+}
+
+func Test_contentHash_compareToStored_v1(t *testing.T) {
+	currentV1 := BuildingBlockDefinitionVersionContentHash{hashVersion: 1, hashValue: "v1:sameHash"}
+
+	assert.Equal(t, hashSame, currentV1.compareToStored("v1:sameHash"))
+	assert.Equal(t, hashDifferent, currentV1.compareToStored("v1:otherHash"))
+}
+
+func Test_contentHash_changeDetectionEndToEnd(t *testing.T) {
+	stored := forTestCalculateContentHash(t, versionSpecJson).toBase64()
+
+	sameAgain := forTestCalculateContentHash(t, versionSpecJson)
+	irrelevant := forTestCalculateContentHash(t, versionSpecIrrelevantChangeJson)
+	relevant := forTestCalculateContentHash(t, versionSpecRelevantChangeJson)
+
+	assert.Equal(t, hashSame, sameAgain.compareToStored(stored))
+	assert.Equal(t, hashSame, irrelevant.compareToStored(stored))
+	assert.Equal(t, hashDifferent, relevant.compareToStored(stored))
+}
+
+// Mirrors the released-version immutability guard's fail-safe: when the stored hash is from a legacy /
+// unknown algorithm version (e.g. written by an older provider and never refreshed), it is incomparable
+// to the current-version hash. The guard then recomputes the released spec from state AT THE CURRENT
+// version so the comparison becomes meaningful again — a genuine change is detected (would reject) and
+// an unchanged spec is recognized (no-op), instead of the old silent "no change" guess.
+func Test_contentHash_incomparableStoredHash_resolvedByRecomputeAtCurrentVersion(t *testing.T) {
+	changedPlanHash := forTestCalculateContentHash(t, versionSpecRelevantChangeJson)
+	unchangedPlanHash := forTestCalculateContentHash(t, versionSpecJson)
+
+	// A legacy/stale stored hash is incomparable to the current-version plan hash - the case that used to
+	// be silently treated as "no change".
+	staleStored := "v1:someLegacyHashValue"
+	require.Equal(t, hashIncomparable, changedPlanHash.compareToStored(staleStored))
+
+	// Guard's fail-safe: recompute the released spec (the authoritative released version in state) at the
+	// current version, then compare like-for-like.
+	authoritative := forTestCalculateContentHash(t, versionSpecJson)
+
+	// A genuine change is now detected (guard rejects the mutation of an immutable version) ...
+	assert.Equal(t, hashDifferent, changedPlanHash.compareToStored(authoritative.toBase64()))
+	// ... and an unchanged spec is a no-op (no spurious rejection).
+	assert.Equal(t, hashSame, unchangedPlanHash.compareToStored(authoritative.toBase64()))
+}
+
+func Test_versionContentHash_plaintextSecret(t *testing.T) {
+	var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
+	require.NoError(t, json.Unmarshal(versionSpecPlaintextSecretJson, &versionSpec))
+	var diags diag.Diagnostics
+	calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Detail(), "version_spec carries a plaintext secret value, which must not be hashed")
+}
+
+// Test_versionContentHash_userDataNamedPlaintext guards against the false positive from issue #196: an
+// input named "plaintext" is a user-chosen map key, not a secret, so it must hash successfully rather than
+// trip the plaintext safeguard (the old JSON-key-based safeguard rejected it).
+func Test_versionContentHash_userDataNamedPlaintext(t *testing.T) {
+	const userDataJson = `{
+		"inputs": {
+			"plaintext": {
+				"displayName": "Plaintext",
+				"type": "STRING",
+				"assignmentType": "STATIC",
+				"argument": "hello"
+			}
+		},
+		"implementation": {"terraform": {}}
+	}`
+	var versionSpec client.MeshBuildingBlockDefinitionVersionSpec
+	require.NoError(t, json.Unmarshal([]byte(userDataJson), &versionSpec))
+	var diags diag.Diagnostics
+	actualHashStr := calculateBuildingBlockDefinitionVersionContentHash(versionSpec, &diags).toBase64()
+	require.Empty(t, diags)
+	assert.NotEmpty(t, actualHashStr)
+}
+
+// Test_versionContentHash_ignoresPerVersionFields pins the invariant that the content hash is independent
+// of the per-BBD buildingBlockDefinitionRef and the per-version versionNumber/state (all stripped before
+// hashing). Were they hashed, the same version_spec would hash differently across BBDs/versions, breaking
+// the released-version immutability and change-detection comparisons. This is the focused, behavioral
+// replacement for the old DisallowMapKeys("buildingBlockDefinitionRef") safeguard, which - like the
+// "plaintext" one - would have misfired on a user-chosen input/output named "buildingBlockDefinitionRef".
+func Test_versionContentHash_ignoresPerVersionFields(t *testing.T) {
+	var base, mutated client.MeshBuildingBlockDefinitionVersionSpec
+	require.NoError(t, json.Unmarshal(versionSpecJson, &base))
+	require.NoError(t, json.Unmarshal(versionSpecJson, &mutated))
+
+	mutated.BuildingBlockDefinitionRef = &client.BuildingBlockDefinitionRef{
+		Kind: client.MeshObjectKind.BuildingBlockDefinition,
+		Uuid: "a-different-bbd-uuid",
+	}
+	mutated.VersionNumber = new(int64(99))
+	mutated.State = client.MeshBuildingBlockDefinitionVersionStateReleased.Ptr()
+
+	var diags diag.Diagnostics
+	baseHash := calculateBuildingBlockDefinitionVersionContentHash(base, &diags).toBase64()
+	mutatedHash := calculateBuildingBlockDefinitionVersionContentHash(mutated, &diags).toBase64()
+	require.Empty(t, diags)
+	assert.Equal(t, baseHash, mutatedHash, "buildingBlockDefinitionRef/versionNumber/state must not affect the content hash")
+}
+
+func forTestCalculateContentHash(t *testing.T, raw []byte) BuildingBlockDefinitionVersionContentHash {
+	t.Helper()
+
+	var spec client.MeshBuildingBlockDefinitionVersionSpec
+	require.NoError(t, json.Unmarshal(raw, &spec))
+
+	var diags diag.Diagnostics
+	h := calculateBuildingBlockDefinitionVersionContentHash(spec, &diags)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	require.Empty(t, diags)
+	require.NotNil(t, h)
+
+	return h
+}

--- a/internal/provider/building_block_resource.go
+++ b/internal/provider/building_block_resource.go
@@ -130,6 +130,8 @@ func (r *buildingBlockResource) Schema(ctx context.Context, req resource.SchemaR
 								MarkdownDescription: "Content hash of the building block definition version. " +
 									"Its purpose is to detect content changes of a **draft** BBD (whose version `uuid` stays the same) " +
 									"and conveniently re-run the building block when it changes.<br>" +
+									"When wired from a definition's computed `content_hash`, a change caused *only* by a hash-algorithm " +
+									"version upgrade (e.g. after upgrading the provider) does **not** trigger a re-run.<br>" +
 									"It is provider-only and never sent to the backend, so changing it can also be used to force a " +
 									"manual re-run — use with care; with a plain workspace key (`BUILDINGBLOCK_SAVE`) this requires the " +
 									"definition to have run transparency enabled (admins and the definition's platform operator are exempt).<br>" +
@@ -798,33 +800,64 @@ func requiresReplaceParentsWhenVersionUnchanged(ctx context.Context, req planmod
 // rerunNeeded is the single shared predicate determining whether an Update should trigger a run.
 // Used by both ModifyPlan and Update.
 // Semantics:
-//   - version-ref uuid differs → rerun
-//   - content_hash: rerun only when BOTH non-nil and different, or plan non-nil and state nil (newly set);
-//     plan nil + state non-nil (user removed content_hash) → NOT a rerun
-//   - inputs differ → rerun
-//   - parent set differs → rerun (parents change re-resolves BUILDING_BLOCK_OUTPUT inputs)
+//  1. version-ref uuid differs → rerun
+//  2. content_hash:
+//     - rerun when plan non-nil and state nil (newly set) → rerun.
+//     - both non-nil and hashes are different → rerun.
+//     - plan nil + state non-nil (user removed content_hash) → NOT a rerun.
+//     - an arbitrary (non-versioned) content_hash value the user sets to force a manual rerun → rerun.
+//  3. inputs differ → rerun.
+//  4. parent set differs → rerun.
 func rerunNeeded(plan, state client.MeshBuildingBlockV2Spec) bool {
+	// uuid change detection
 	if plan.BuildingBlockDefinitionVersionRef.Uuid != state.BuildingBlockDefinitionVersionRef.Uuid {
 		return true
 	}
+
+	// content_hash change detection
 	planHash := plan.BuildingBlockDefinitionVersionRef.ContentHash
 	stateHash := state.BuildingBlockDefinitionVersionRef.ContentHash
 	if planHash != nil {
-		// plan non-nil + state nil → newly set → rerun
-		// plan non-nil + state non-nil + different → changed → rerun
-		if stateHash == nil || *planHash != *stateHash {
+		if stateHash == nil || compareContentHashes(*planHash, *stateHash) == hashDifferent {
 			return true
 		}
 	}
-	// plan nil + state non-nil → user removed content_hash → NOT a rerun
+
+	// inputs change detection
 	if planInputsChanged(plan.Inputs, state.Inputs) {
 		return true
 	}
-	// parent set differs → rerun (parents change re-resolves BUILDING_BLOCK_OUTPUT inputs)
+
+	// parent building blocks change detection
 	if !reflect.DeepEqual(plan.ParentBuildingBlocks, state.ParentBuildingBlocks) {
 		return true
 	}
+
 	return false
+}
+
+func compareContentHashes(planHash, stateHash string) hashComparison {
+	planParsed, err := getVersionedHashFromString(planHash)
+	if err != nil {
+		return stringBasedHashComparison(planHash, stateHash)
+	}
+
+	cmp := planParsed.compareToStored(stateHash)
+	// hashIncomparable means either a different algorithm version, or the state string is free-form.
+	// Only the latter should fall back to a plain comparison; a genuine version mismatch stays incomparable.
+	if cmp == hashIncomparable {
+		if _, err := getVersionedHashFromString(stateHash); err != nil {
+			return stringBasedHashComparison(planHash, stateHash) // state side free-form → plain comparison
+		}
+	}
+	return cmp
+}
+
+func stringBasedHashComparison(planHash, stateHash string) hashComparison {
+	if planHash != stateHash {
+		return hashDifferent
+	}
+	return hashSame
 }
 
 func (r *buildingBlockResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -898,6 +931,25 @@ func (r *buildingBlockResource) ModifyPlan(ctx context.Context, req resource.Mod
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// When plan and state content_hash differ only by their hash-algorithm version (see
+	// classifyContentHash), the building block is deliberately NOT re-run. Warn so the user knows a
+	// genuine content change - if any - was not picked up, and how to force a re-run.
+	if planHash := planSpec.BuildingBlockDefinitionVersionRef.ContentHash; planHash != nil {
+		if stateHash := stateSpec.BuildingBlockDefinitionVersionRef.ContentHash; stateHash != nil {
+			if compareContentHashes(*planHash, *stateHash) == hashIncomparable {
+				resp.Diagnostics.AddAttributeWarning(
+					path.Root("spec").AtName("building_block_definition_version_ref").AtName("content_hash"),
+					"Building block definition version content hash version changed; not re-running",
+					"The referenced version's content_hash changed only because it was produced by a different "+
+						"hash-algorithm version (for example after upgrading the provider), so the building block was "+
+						"not re-run. If the version's content actually changed and you want to force a re-run, set "+
+						"spec.building_block_definition_version_ref.content_hash to an arbitrary new value.",
+				)
+			}
+		}
+	}
+
 	if rerunNeeded(planSpec, stateSpec) || secretRotated {
 		triggerRun()
 	}

--- a/internal/provider/building_block_resource_test.go
+++ b/internal/provider/building_block_resource_test.go
@@ -1380,3 +1380,78 @@ func bbv3SizeEnvInputChecks(buildingBlockAddr testconfig.Traversal) []statecheck
 		statecheck.ExpectKnownValue(buildingBlockAddr.String(), tfjsonpath.New("spec").AtMapKey("inputs").AtMapKey("environment").AtMapKey("value"), knownvalue.StringExact(`"dev"`)),
 	}
 }
+
+// Test_compareContentHashes tests the content hash comparison logic for the building block rerun decision.
+func Test_compareContentHashes(t *testing.T) {
+	v2a := BuildingBlockDefinitionVersionContentHash{hashVersion: 2, hashValue: "aaa"}.toBase64()
+	v2b := BuildingBlockDefinitionVersionContentHash{hashVersion: 2, hashValue: "bbb"}.toBase64()
+	v1 := "v1:someLegacyHashValue"
+
+	tests := []struct {
+		name      string
+		planHash  string
+		stateHash string
+		want      hashComparison
+	}{
+		{"versioned, same version, same value", v2a, v2a, hashSame},
+		{"versioned, same version, different value", v2a, v2b, hashDifferent},
+		{"versioned, different algorithm version", v2a, v1, hashIncomparable},
+		{"different algorithm version, other direction", v1, v2a, hashIncomparable},
+		{"free-form, changed", "2", "1", hashDifferent},
+		{"free-form, unchanged", "x", "x", hashSame},
+		{"free-form plan vs versioned state", "manual", v2a, hashDifferent},
+		{"versioned plan vs free-form state", v2a, "manual", hashDifferent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, compareContentHashes(tt.planHash, tt.stateHash))
+		})
+	}
+}
+
+func Test_rerunNeeded(t *testing.T) {
+	v2a := BuildingBlockDefinitionVersionContentHash{hashVersion: 2, hashValue: "aaa"}.toBase64()
+	v2b := BuildingBlockDefinitionVersionContentHash{hashVersion: 2, hashValue: "bbb"}.toBase64()
+	v1 := "v1:someLegacyHashValue"
+
+	spec := func(uuid string, contentHash *string, inputs map[string]*client.MeshBuildingBlockInput, parents ...client.MeshBuildingBlockParent) client.MeshBuildingBlockV2Spec {
+		return client.MeshBuildingBlockV2Spec{
+			BuildingBlockDefinitionVersionRef: client.MeshBuildingBlockV2DefinitionVersionRef{
+				Uuid:        uuid,
+				ContentHash: contentHash,
+			},
+			Inputs:               inputs,
+			ParentBuildingBlocks: parents,
+		}
+	}
+	input := func(sensitive bool) *client.MeshBuildingBlockInput {
+		return &client.MeshBuildingBlockInput{IsSensitive: sensitive}
+	}
+	parent := client.MeshBuildingBlockParent{BuildingBlockUuid: "parent-1", DefinitionUuid: "def-1"}
+
+	tests := []struct {
+		name  string
+		plan  client.MeshBuildingBlockV2Spec
+		state client.MeshBuildingBlockV2Spec
+		want  bool
+	}{
+		{"uuid differs", spec("uuid-2", nil, nil), spec("uuid-1", nil, nil), true},
+		{"content_hash newly set", spec("uuid", &v2a, nil), spec("uuid", nil, nil), true},
+		{"content_hash removed", spec("uuid", nil, nil), spec("uuid", &v2a, nil), false},
+		{"content_hash version mismatch", spec("uuid", &v2a, nil), spec("uuid", &v1, nil), false},
+		{"content_hash changed", spec("uuid", &v2a, nil), spec("uuid", &v2b, nil), true},
+		{"content_hash arbitrary value changed", spec("uuid", new("force-rerun"), nil), spec("uuid", new("previous-value"), nil), true},
+		{"content_hash unchanged", spec("uuid", &v2a, nil), spec("uuid", &v2a, nil), false},
+		{"inputs added", spec("uuid", nil, map[string]*client.MeshBuildingBlockInput{"a": input(false)}), spec("uuid", nil, nil), true},
+		{"inputs changed", spec("uuid", nil, map[string]*client.MeshBuildingBlockInput{"a": input(true)}), spec("uuid", nil, map[string]*client.MeshBuildingBlockInput{"a": input(false)}), true},
+		{"inputs unchanged", spec("uuid", nil, map[string]*client.MeshBuildingBlockInput{"a": input(false)}), spec("uuid", nil, map[string]*client.MeshBuildingBlockInput{"a": input(false)}), false},
+		{"parents differ", spec("uuid", nil, nil, parent), spec("uuid", nil, nil), true},
+		{"parents unchanged", spec("uuid", nil, nil, parent), spec("uuid", nil, nil, parent), false},
+		{"all equal", spec("uuid", &v2a, map[string]*client.MeshBuildingBlockInput{"a": input(false)}, parent), spec("uuid", &v2a, map[string]*client.MeshBuildingBlockInput{"a": input(false)}, parent), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, rerunNeeded(tt.plan, tt.state))
+		})
+	}
+}


### PR DESCRIPTION
…on I/O without affecting the calculated hash for change detection

CU-86cabn76y

---
### Summary
Added a manageable **display_order** field to building block definition version inputs and outputs.

**Implementation**:

**Client**
DisplayOrder int64 with json:"displayOrder,omitempty" on both MeshBuildingBlockDefinitionInput and MeshBuildingBlockDefinitionOutput.

**Schema**
 display_order Int64Attribute on inputs and outputs, Optional + Computed + Default(0) — the Default is what keeps re-plans clean given the backend returns 0 when unset.

**Content hash** 
stripped to 0 before hashing, so reordering never changes content_hash or forces a new version

**Released immutability** 
 displayOrdersDiffer guard in Update — needed because display_order is outside the hash, so this restores the "released versions are immutable" behavior with a clear error.

**Mock**
mirrors input→output display_order for manual BBDs.

---

:warning: depends on meshfed-api released with https://github.com/meshcloud/meshfed-release/pull/10263