### PR TITLE
fix: retry DELETE and widen retry budget for backend restarts

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,8 +59,12 @@ func New(ctx context.Context, rootUrl *url.URL, userAgent string, auth Authoriza
 	httpClient := internal.WithRetry(
 		internal.NewHttpClient(rootUrl, userAgent, auth),
 		internal.RetryOptions{
-			MaxRetries:       10,
-			Backoff:          internal.ExponentialBackoff{MinWait: 1 * time.Second, MaxWait: 10 * time.Second},
+			// Sized to ride out a full meshStack backend restart (e.g. an OOMKill followed by a
+			// Spring Boot cold start), which can leave the gateway returning 503 for ~2-3 minutes —
+			// well beyond the previous ~75s budget. This backoff sequence sums to ~4 minutes:
+			// 1+2+4+8+16+30*7 seconds.
+			MaxRetries:       12,
+			Backoff:          internal.ExponentialBackoff{MinWait: 1 * time.Second, MaxWait: 30 * time.Second},
 			WhitelistedPaths: map[string][]string{"POST": {apiLoginPath}},
 		},
 	)

--- a/client/internal/http_client_test.go
+++ b/client/internal/http_client_test.go
@@ -129,6 +129,21 @@ func TestHttpClient(t *testing.T) {
 		assert.Equal(t, 1, attempts, "PATCH must not be retried")
 	})
 
+	t.Run("DoRequest with DELETE (retried, idempotent)", func(t *testing.T) {
+		attempts := 0
+		client := WithRetry(newTestClientWithServer(t, func(resp http.ResponseWriter, req *http.Request) {
+			attempts++
+			if attempts == 1 {
+				resp.WriteHeader(503)
+				return
+			}
+			resp.WriteHeader(http.StatusNoContent)
+		}), RetryOptions{MaxRetries: 3, Backoff: &retryTestBackoff{}})
+		_, err := DoRequest[any](t.Context(), client, http.MethodDelete, client.RootUrl.JoinPath("delete"))
+		require.NoError(t, err)
+		assert.Equal(t, 2, attempts, "DELETE must be retried after a 503")
+	})
+
 	t.Run("DoRequest with PUT replays body on retry", func(t *testing.T) {
 		attempt := 0
 		client := WithRetry(newTestClientWithServer(t, func(resp http.ResponseWriter, req *http.Request) {

--- a/client/internal/retry.go
+++ b/client/internal/retry.go
@@ -14,8 +14,8 @@ import (
 )
 
 // WithRetry sets up the given client to retry certain requests.
-// GET and PUT are retried by default, POST only if the path is explicitly whitelisted.
-// See RetryOptions.
+// The idempotent methods GET, PUT and DELETE are retried by default, POST only if the path is
+// explicitly whitelisted. See RetryOptions.
 func WithRetry(c HttpClient, options RetryOptions) HttpClient {
 	next := http.DefaultTransport
 	if c.Transport != nil {
@@ -40,7 +40,10 @@ func WithRetry(c HttpClient, options RetryOptions) HttpClient {
 				return false
 			}
 			switch req.Method {
-			case http.MethodGet, http.MethodPut:
+			case http.MethodGet, http.MethodPut, http.MethodDelete:
+				// Idempotent methods are safe to retry: replaying them cannot create duplicate
+				// side effects. A DELETE that actually succeeded server-side before a proxy 503
+				// simply yields a 404 on replay, which delete handlers already treat as done.
 				return true
 			}
 			if whitelisted, found := whitelistedByMethodAndUrl[req.Method]; found {


### PR DESCRIPTION
## Why

The `meshstack-smoke-test` nightly run [28768021397](https://github.com/meshcloud/meshstack-smoke-test/actions/runs/28768021397) failed across many hub e2e tests, all with `http error 503, response '<html><body><h1>503 Service Unavailable</h1>'` from `federation.dev.meshcloud.io`.

Root cause was on the backend, not the tests: the `meshfed` pod was **OOMKilled** (`exitCode 137`) at `04:37:22Z` and Spring Boot took ~2-3 minutes to cold-start, during which the gateway had no ready backend and returned `503` to every client. (This is a recurring pattern on dev — the container OOMs roughly daily; a separate infra ticket tracks the memory sizing/leak.)

The provider *does* retry 503, but two gaps let the transient outage surface as hard test failures:

1. **`DELETE` was never retried.** Only `GET`/`PUT` (and whitelisted `POST /api/login`) were retryable, so a building block delete that hit the 503 failed immediately with zero retries.
2. **The retry budget (~75s) was shorter than the outage.** `MaxRetries 10` × exponential backoff (`MinWait 1s`, `MaxWait 10s`) sums to ~75s. The retried `GET` paths (BBD read, status polling, and the `/mesh/info` version check run on every provider configure/destroy) exhausted their retries ~75-95s after the OOMKill, before meshfed finished booting. Note `poll.go` wraps a GET error as `NonRetryableError`, so the transport-level retry is the *only* cushion during await.

## What

- Add `DELETE` to the idempotent methods retried on `429`/`502`/`503`/`504` and transport errors. Replaying a `DELETE` is safe: one that already succeeded server-side before a proxy 503 simply yields a `404` on replay, which the delete handlers already treat as done.
- Widen the retry budget from ~75s to ~4 minutes (`MaxRetries` 10 → 12, `MaxWait` 10s → 30s: `1+2+4+8+16+30×7`) so operations can ride out a full backend restart.

## Test

- New unit test `DoRequest with DELETE (retried, idempotent)` asserts a `DELETE` is replayed after a 503.
- `go build ./...` and `go test ./client/internal/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)