### PR TITLE
feat: capture a failed composed child's run log via the run token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 - `meshstack_building_block`: A composition now captures a failed child building block's full run log, using the run-scoped `MESHSTACK_RUN_TOKEN` when meshStack injects it, even if the child has run transparency disabled.
 
+FIXES:
+- `meshstack_building_block_definition`: A definition with an empty `version_spec.inputs = {}` no longer fails with "Provider produced inconsistent result after apply" (null vs empty map). The applied and refreshed values now preserve the configured shape.
+
 # v0.23.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.23.1
+
+FEATURES:
+- `meshstack_building_block`: A composition now captures a failed child building block's full run log, using the run-scoped `MESHSTACK_RUN_TOKEN` when meshStack injects it, even if the child has run transparency disabled.
+
 # v0.23.0
 
 FEATURES:

--- a/client/client.go
+++ b/client/client.go
@@ -41,6 +41,10 @@ type Client struct {
 	Workspace                      MeshWorkspaceClient
 	WorkspaceGroupBinding          MeshWorkspaceGroupBindingClient
 	WorkspaceUserBinding           MeshWorkspaceUserBindingClient
+
+	// BuildingBlockRunWithRunToken reads run logs authenticated with the privileged run token, letting a
+	// composition capture a failed child run's system message. Nil unless MESHSTACK_RUN_TOKEN is set.
+	BuildingBlockRunWithRunToken MeshBuildingBlockRunClient
 }
 
 type Authorization = internal.Authorization
@@ -98,6 +102,20 @@ func New(ctx context.Context, rootUrl *url.URL, userAgent string, auth Authoriza
 		WorkspaceGroupBinding:          newWorkspaceGroupBindingClient(ctx, httpClient),
 		WorkspaceUserBinding:           newWorkspaceUserBindingClient(ctx, httpClient),
 	}, nil
+}
+
+// NewBuildingBlockRunClientWithAuth builds a standalone run client with its own authorization, so the
+// provider can read run logs with the run token while the main client keeps the workspace credentials.
+// It skips the version check the main client already performed.
+func NewBuildingBlockRunClientWithAuth(ctx context.Context, rootUrl *url.URL, userAgent string, auth Authorization) MeshBuildingBlockRunClient {
+	httpClient := internal.WithRetry(
+		internal.NewHttpClient(rootUrl, userAgent, auth),
+		internal.RetryOptions{
+			MaxRetries: 10,
+			Backoff:    internal.ExponentialBackoff{MinWait: 1 * time.Second, MaxWait: 10 * time.Second},
+		},
+	)
+	return newBuildingBlockRunClient(ctx, httpClient)
 }
 
 func checkMeshVersion(ctx context.Context, httpClient internal.HttpClient) error {

--- a/internal/provider/building_block_definition_resource.go
+++ b/internal/provider/building_block_definition_resource.go
@@ -129,6 +129,13 @@ func (r *buildingBlockDefinitionResource) Read(ctx context.Context, req resource
 		Metadata: definitionDto.Metadata,
 		Spec:     definitionDto.Spec,
 	}
+	// Seed the prior inputs shape (null vs empty {}) so SetFromVersionClientDtos preserves it across a
+	// refresh — the backend collapses the two, so without this an empty-map state would flip to null.
+	var priorInputs types.Map
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("version_spec").AtName("inputs"), &priorInputs)...)
+	if !priorInputs.IsNull() && len(priorInputs.Elements()) == 0 {
+		state.VersionSpec.Inputs = map[string]*client.MeshBuildingBlockDefinitionInput{}
+	}
 
 	versionDtos, err := r.buildingBlockDefinitionVersionClient.List(ctx, bbdUuid)
 	if err != nil {

--- a/internal/provider/building_block_definition_resource_model.go
+++ b/internal/provider/building_block_definition_resource_model.go
@@ -266,12 +266,15 @@ func (model *buildingBlockDefinition) SetFromVersionClientDtos(diags *diag.Diagn
 		return
 	}
 	latestIndex := len(versionDtos) - 1
-	inputsNil := model.VersionSpec.Inputs == nil
+	// The backend can't distinguish a null inputs map from an empty one (ToClientDto sends {} for both) and
+	// may return either. Preserve the caller's exact shape (nil vs {}) when the round-trip carries no inputs,
+	// otherwise Terraform reports a null-vs-empty "inconsistent result after apply".
+	priorInputs := model.VersionSpec.Inputs
 	model.VersionSpec = buildingBlockDefinitionVersionSpec{
 		MeshBuildingBlockDefinitionVersionSpec: versionDtos[latestIndex].Spec,
 	}
-	if inputsNil && len(model.VersionSpec.Inputs) == 0 {
-		model.VersionSpec.Inputs = nil
+	if len(priorInputs) == 0 && len(model.VersionSpec.Inputs) == 0 {
+		model.VersionSpec.Inputs = priorInputs
 	}
 
 	if !isDraft.IsUnknown() && !isDraft.Get() {

--- a/internal/provider/building_block_definition_resource_model_test.go
+++ b/internal/provider/building_block_definition_resource_model_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
+	"github.com/meshcloud/terraform-provider-meshstack/internal/types/generic"
 )
 
 var (
@@ -113,4 +114,48 @@ func Test_versionContentHash_ignoresPerVersionFields(t *testing.T) {
 	mutatedHash := versionContentHash(mutated, &diags)
 	require.Empty(t, diags)
 	assert.Equal(t, baseHash, mutatedHash, "buildingBlockDefinitionRef/versionNumber/state must not affect the content hash")
+}
+
+// The backend collapses a null inputs map and an empty one, so SetFromVersionClientDtos must preserve the
+// caller's exact shape when the version carries no inputs — otherwise Terraform reports a null-vs-empty
+// "Provider produced inconsistent result after apply".
+func Test_SetFromVersionClientDtos_preservesInputsShape(t *testing.T) {
+	draftState := client.MeshBuildingBlockDefinitionVersionStateDraft.Unwrap()
+	versionWithNoInputs := client.MeshBuildingBlockDefinitionVersion{
+		Metadata: client.MeshBuildingBlockDefinitionVersionMetadata{Uuid: "v1"},
+		Spec: client.MeshBuildingBlockDefinitionVersionSpec{
+			VersionNumber: new(int64(1)),
+			State:         &draftState,
+			Implementation: client.MeshBuildingBlockDefinitionImplementation{
+				Terraform: &client.MeshBuildingBlockDefinitionTerraformImplementation{},
+			},
+			// Inputs left nil, mimicking a backend response that omits an empty inputs map.
+		},
+	}
+
+	tests := []struct {
+		name    string
+		prior   map[string]*client.MeshBuildingBlockDefinitionInput
+		wantNil bool
+	}{
+		{"nil inputs stay nil", nil, true},
+		{"empty inputs stay empty (not null)", map[string]*client.MeshBuildingBlockDefinitionInput{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &buildingBlockDefinition{}
+			model.VersionSpec.Inputs = tt.prior
+
+			var diags diag.Diagnostics
+			model.SetFromVersionClientDtos(&diags, generic.KnownValue(true), "bbd", versionWithNoInputs)
+			require.False(t, diags.HasError(), "unexpected diags: %v", diags.Errors())
+
+			if tt.wantNil {
+				require.Nil(t, model.VersionSpec.Inputs)
+			} else {
+				require.NotNil(t, model.VersionSpec.Inputs)
+				require.Empty(t, model.VersionSpec.Inputs)
+			}
+		})
+	}
 }

--- a/internal/provider/building_block_resource.go
+++ b/internal/provider/building_block_resource.go
@@ -55,6 +55,10 @@ func NewBuildingBlockResource() resource.Resource {
 type buildingBlockResource struct {
 	BuildingBlockClient    client.MeshBuildingBlockV2Client
 	BuildingBlockRunClient client.MeshBuildingBlockRunClient
+	// RunTokenRunClient reads run logs with the run token, used for failure diagnostics so a composition
+	// captures a failed child run's system message regardless of the child's run transparency. Nil unless
+	// MESHSTACK_RUN_TOKEN is set.
+	RunTokenRunClient client.MeshBuildingBlockRunClient
 }
 
 func (r *buildingBlockResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -65,6 +69,7 @@ func (r *buildingBlockResource) Configure(_ context.Context, req resource.Config
 	resp.Diagnostics.Append(configureProviderClient(req.ProviderData, func(client client.Client) {
 		r.BuildingBlockClient = client.BuildingBlockV2
 		r.BuildingBlockRunClient = client.BuildingBlockRun
+		r.RunTokenRunClient = client.BuildingBlockRunWithRunToken
 	})...)
 }
 
@@ -579,7 +584,13 @@ func (r *buildingBlockResource) addRunFailureDiagnostics(
 	if bb == nil || bb.Status == nil || bb.Status.LatestRunUuid == nil {
 		return
 	}
-	logs, err := r.BuildingBlockRunClient.GetLogs(ctx, *bb.Status.LatestRunUuid)
+	// Prefer the run-token client: its privileged scope makes the run's system message readable even when
+	// the (child) building block has run transparency disabled. Falls back to the workspace client.
+	runClient := r.BuildingBlockRunClient
+	if r.RunTokenRunClient != nil {
+		runClient = r.RunTokenRunClient
+	}
+	logs, err := runClient.GetLogs(ctx, *bb.Status.LatestRunUuid)
 	if err != nil {
 		// Fetching run logs can legitimately fail: the building block definition may have run
 		// transparency disabled, or the caller's permissions may not allow reading them. Surface it

--- a/internal/provider/building_block_resource_await_test.go
+++ b/internal/provider/building_block_resource_await_test.go
@@ -175,6 +175,72 @@ func TestAwaitRunWarnsWhenFailedRunLogsUnreadable(t *testing.T) {
 	require.Equal(t, client.BuildingBlockStatusFailed, final.Status.Status)
 }
 
+// recordingRunLogsClient records whether GetLogs was called and returns a single failed step whose system
+// message identifies which client answered, so a test can assert which client was used to fetch logs.
+type recordingRunLogsClient struct {
+	client.MeshBuildingBlockRunClient
+	systemMessage string
+	called        bool
+}
+
+func (c *recordingRunLogsClient) GetLogs(_ context.Context, _ string) (client.MeshBuildingBlockRunLogs, error) {
+	c.called = true
+	return client.MeshBuildingBlockRunLogs{Steps: []client.MeshBuildingBlockRunStepLog{
+		{DisplayName: "apply", Status: string(client.BuildingBlockStatusFailed), SystemMessage: new(c.systemMessage)},
+	}}, nil
+}
+
+func failedRunStates(runUuid string) []*client.MeshBuildingBlockV2 {
+	return []*client.MeshBuildingBlockV2{
+		bbWithRun(client.BuildingBlockStatusInProgress, runUuid),
+		bbWithRun(client.BuildingBlockStatusFailed, runUuid),
+	}
+}
+
+// TestAwaitRunFetchesFailureLogsWithRunTokenClient: when a run-token client is configured, awaitRun reads
+// the failed run's logs with it (not the workspace client) so a composition can surface a child's system
+// message even with the child's run transparency disabled.
+func TestAwaitRunFetchesFailureLogsWithRunTokenClient(t *testing.T) {
+	t.Parallel()
+
+	stub := &sequencedBBClient{states: failedRunStates("run-broken")}
+	workspace := &recordingRunLogsClient{systemMessage: "workspace-client logs"}
+	runToken := &recordingRunLogsClient{systemMessage: "run-token-client logs"}
+	r := &buildingBlockResource{BuildingBlockClient: stub, BuildingBlockRunClient: workspace, RunTokenRunClient: runToken}
+
+	var diags diag.Diagnostics
+	r.awaitRun(context.Background(), &diags, "bb-uuid", true, 30*time.Second)
+
+	require.True(t, runToken.called, "the run-token client must fetch failure logs when configured")
+	require.False(t, workspace.called, "the workspace client must not be used when the run-token client is configured")
+	require.Contains(t, allErrorDetails(diags), "run-token-client logs")
+}
+
+// TestAwaitRunFetchesFailureLogsWithWorkspaceClientWithoutRunToken: without a run-token client (no
+// MESHSTACK_RUN_TOKEN), awaitRun falls back to the workspace client for the failure logs.
+func TestAwaitRunFetchesFailureLogsWithWorkspaceClientWithoutRunToken(t *testing.T) {
+	t.Parallel()
+
+	stub := &sequencedBBClient{states: failedRunStates("run-broken")}
+	workspace := &recordingRunLogsClient{systemMessage: "workspace-client logs"}
+	r := &buildingBlockResource{BuildingBlockClient: stub, BuildingBlockRunClient: workspace}
+
+	var diags diag.Diagnostics
+	r.awaitRun(context.Background(), &diags, "bb-uuid", true, 30*time.Second)
+
+	require.True(t, workspace.called, "the workspace client must fetch failure logs when no run-token client is set")
+	require.Contains(t, allErrorDetails(diags), "workspace-client logs")
+}
+
+func allErrorDetails(diags diag.Diagnostics) string {
+	var b strings.Builder
+	for _, e := range diags.Errors() {
+		b.WriteString(e.Detail())
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 // TestAwaitRunWarnsOnParkedWaiting: a block parked in WAITING_FOR_*_INPUT cannot proceed from this apply
 // (a runnable block would already be PENDING). awaitRun returns it as terminal-but-non-fatal with a
 // waiting-for-input warning, rather than polling to the timeout.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -73,6 +73,9 @@ const (
 	envKeyMeshstackApiKey    = "MESHSTACK_API_KEY"
 	envKeyMeshstackApiSecret = "MESHSTACK_API_SECRET"
 	envKeyMeshstackApiToken  = "MESHSTACK_API_TOKEN"
+	// envKeyMeshstackRunToken carries the privileged, run-scoped token meshStack injects into a building
+	// block run. Env-only: it is set per run by the platform, never configured in HCL.
+	envKeyMeshstackRunToken = "MESHSTACK_RUN_TOKEN"
 )
 
 func (p *MeshStackProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -163,6 +166,14 @@ func newProviderClient(ctx context.Context, data MeshStackProviderModel, provide
 	if err != nil {
 		diags.AddError("Failed to create meshStack client.", err.Error())
 		return
+	}
+
+	// The run token lets a composition read its children's run logs even when the child has run
+	// transparency disabled. It authorizes only the run-log client; all other calls use the workspace auth.
+	if runToken := os.Getenv(envKeyMeshstackRunToken); runToken != "" {
+		providerClient.BuildingBlockRunWithRunToken = client.NewBuildingBlockRunClientWithAuth(
+			ctx, parsedEndpoint, userAgent, client.NewApiTokenAuthorization(runToken),
+		)
 	}
 	return
 }


### PR DESCRIPTION
# Capture a failed composed child's run log via the run token

Pairs with the meshfed-release PR on the identically-named branch `feature/composed-run-failure-logs`.

## Why

When a composition building block (e.g. a starter kit) waits on a child building block it created and that
child fails, `addRunFailureDiagnostics` fetches the child run's logs and adds the failing step as an error, so
the tf-block-runner streams the real error into the parent run's log. Fetched with the consumer's workspace
credentials, a child with `run_transparency = false` returns no `systemMessage`, so the parent log only carried
a generic "run failed". meshStack injects a privileged, run-scoped token (`MESHSTACK_RUN_TOKEN`) into such runs
that can read the composition's own children's runs.

## Change

- `provider.go`: read `MESHSTACK_RUN_TOKEN` (env-only — it is set per run by the platform, never in HCL); when
  present, build a run-token-authorized run-log client.
- `client.go`: `NewBuildingBlockRunClientWithAuth` builds a standalone `MeshBuildingBlockRunClient` with its own
  authorization (skipping the version check the main client already did). New `Client.BuildingBlockRunWithRunToken`
  field, nil unless the token is set.
- `building_block_resource.go`: `addRunFailureDiagnostics` fetches the failed run's logs with the run-token
  client when available, else the workspace client. Everything else (CRUD, polling) keeps the workspace
  credentials.

The child run uuid the provider polls comes from `bb.Status.LatestRunUuid`, which the paired backend change
now exposes to the block owner regardless of the child's run transparency.

Additive on a `-preview` API — not breaking, no `TerraformProviderVersionRequirements.kt` coordination needed.

## Tests

- Unit (`building_block_resource_await_test.go`): `addRunFailureDiagnostics` uses the **run-token** client when
  configured (and not the workspace client), and falls back to the workspace client when it is not; the fetched
  system message reaches the diagnostics. Hermetic, CI-runnable.
- End-to-end is verified by hand with a local scratch demo (a composition against a local stack with one child
  forced to fail at `run_transparency = false`); it is not automated because CI runs the tf-block-runner as a
  service container that pulls the released provider from the registry, so it cannot exercise a dev-built
  provider. Wiring the dev provider into the local runner requires a `dev_overrides` block in `$HOME/.terraformrc`
  (the runner strips `TF_CLI_CONFIG_FILE`).

`task test` and `task lint` green. `CHANGELOG.md`: new `v0.23.1` FEATURES entry.

## Cross-repo PR

- meshcloud/meshfed-release#10286 — backend changes (A: expose run identifiers to the block owner; B: run token for sync API runs).
