### PR TITLE
test: widen building block example/acceptance timeouts from 30s to 2m

### DIFF
--- a/docs/resources/building_block.md
+++ b/docs/resources/building_block.md
@@ -46,9 +46,9 @@ resource "meshstack_building_block" "example_workspace" {
   # create/update wait for the building block run to reach a terminal state; delete waits for
   # deprovisioning. Tune to your runner's typical run duration (defaults to 30m if unset).
   timeouts = {
-    create = "30s"
-    update = "30s"
-    delete = "30s"
+    create = "2m"
+    update = "2m"
+    delete = "2m"
   }
 }
 ```
@@ -85,9 +85,9 @@ resource "meshstack_building_block" "example_tenant" {
   # create/update wait for the building block run to reach a terminal state; delete waits for
   # deprovisioning. Tune to your runner's typical run duration (defaults to 30m if unset).
   timeouts = {
-    create = "30s"
-    update = "30s"
-    delete = "30s"
+    create = "2m"
+    update = "2m"
+    delete = "2m"
   }
 }
 ```

--- a/examples/resources/meshstack_building_block/resource_01_workspace.tf
+++ b/examples/resources/meshstack_building_block/resource_01_workspace.tf
@@ -25,8 +25,8 @@ resource "meshstack_building_block" "example_workspace" {
   # create/update wait for the building block run to reach a terminal state; delete waits for
   # deprovisioning. Tune to your runner's typical run duration (defaults to 30m if unset).
   timeouts = {
-    create = "30s"
-    update = "30s"
-    delete = "30s"
+    create = "2m"
+    update = "2m"
+    delete = "2m"
   }
 }

--- a/examples/resources/meshstack_building_block/resource_02_tenant.tf
+++ b/examples/resources/meshstack_building_block/resource_02_tenant.tf
@@ -29,8 +29,8 @@ resource "meshstack_building_block" "example_tenant" {
   # create/update wait for the building block run to reach a terminal state; delete waits for
   # deprovisioning. Tune to your runner's typical run duration (defaults to 30m if unset).
   timeouts = {
-    create = "30s"
-    update = "30s"
-    delete = "30s"
+    create = "2m"
+    update = "2m"
+    delete = "2m"
   }
 }

--- a/examples/resources/meshstack_building_block/test-support_04_sensitive_user_input.tf
+++ b/examples/resources/meshstack_building_block/test-support_04_sensitive_user_input.tf
@@ -18,10 +18,10 @@ resource "meshstack_building_block" "sensitive_user_input" {
     }
   }
 
-  # Short waits so tests fail fast instead of polling the 30m default if a run hangs.
+  # Bounded waits so tests fail reasonably fast (vs the 30m default) while tolerating a busy runner.
   timeouts = {
-    create = "30s"
-    update = "30s"
-    delete = "30s"
+    create = "2m"
+    update = "2m"
+    delete = "2m"
   }
 }

--- a/examples/resources/meshstack_building_block/test-support_tenant_migration_bb.tf
+++ b/examples/resources/meshstack_building_block/test-support_tenant_migration_bb.tf
@@ -21,10 +21,10 @@ resource "meshstack_building_block" "example_tenant" {
     }
   }
 
-  # Short waits so tests fail fast instead of polling the 30m default if a run hangs.
+  # Bounded waits so tests fail reasonably fast (vs the 30m default) while tolerating a busy runner.
   timeouts = {
-    create = "30s"
-    update = "30s"
-    delete = "30s"
+    create = "2m"
+    update = "2m"
+    delete = "2m"
   }
 }


### PR DESCRIPTION
## What

Bumps the `timeouts` (`create`/`update`/`delete`) on the `meshstack_building_block` example and test-support configs from `30s` to `2m`, and regenerates the resource docs.

## Why

These configs drive **real OpenTofu runs** in acceptance CI against a single shared `tf-block-runner`. At teardown many building blocks destroy concurrently; a destroy that waits behind others (claim + git clone + `tofu destroy`) can exceed the 30s delete budget and fail intermittently with:

```
Error: Building block deletion failed
item *client.MeshBuildingBlockV2 not (yet) in desired state
```

This is the flaky failure seen in `TestAccBuildingBlock/*` teardown (e.g. `06_sensitive_inputs_and_upgrade`, `TestAccBuildingBlocksDataSource/02_version_number_filter`). `2m` tolerates the runner contention while still failing well before the `30m` default, preserving the original "fail fast" intent.

No provider behavior change — the default timeout (30m) is unchanged; only illustrative example/test values are widened.

## Files

- `examples/resources/meshstack_building_block/resource_01_workspace.tf`, `resource_02_tenant.tf` — published examples
- `examples/resources/meshstack_building_block/test-support_04_sensitive_user_input.tf`, `test-support_tenant_migration_bb.tf` — acceptance test-support
- `docs/resources/building_block.md` — regenerated via `go generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)