### PR TITLE
fix: prepare for upcoming WAITING_FOR_APPROVAL building block status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.23.1
+
+FIXES:
+- `meshstack_building_block`: Prepare for the upcoming `WAITING_FOR_APPROVAL` run status (an approval gate coming soon to meshStack — not available yet). Once meshStack starts returning it, an awaited create/update where the run parks for approval will complete with a "waiting for input" warning instead of failing with "unknown building block status; provider may be out of date".
+
 # v0.23.0
 
 FEATURES:

--- a/client/building_block_v2.go
+++ b/client/building_block_v2.go
@@ -28,6 +28,7 @@ var (
 	BuildingBlockStatusWaitingForDependentInput = BuildingBlockStatuses.Entry("WAITING_FOR_DEPENDENT_INPUT")
 	BuildingBlockStatusWaitingForOperatorInput  = BuildingBlockStatuses.Entry("WAITING_FOR_OPERATOR_INPUT")
 	BuildingBlockStatusWaitingForUserInput      = BuildingBlockStatuses.Entry("WAITING_FOR_USER_INPUT")
+	BuildingBlockStatusWaitingForApproval       = BuildingBlockStatuses.Entry("WAITING_FOR_APPROVAL")
 	BuildingBlockStatusPending                  = BuildingBlockStatuses.Entry("PENDING")
 	BuildingBlockStatusInProgress               = BuildingBlockStatuses.Entry("IN_PROGRESS")
 	BuildingBlockStatusSucceeded                = BuildingBlockStatuses.Entry("SUCCEEDED")
@@ -239,12 +240,14 @@ func (c meshBuildingBlockV2Client) Delete(ctx context.Context, uuid string, purg
 }
 
 // IsWaitingForInput reports whether the building block run is paused awaiting
-// human or dependency input. Such a run will not progress on its own, so polling
-// callers treat it as a terminal (but non-fatal) state and surface a warning.
+// human input, a dependency, or an approval. Such a run will not progress on its
+// own, so polling callers treat it as a terminal (but non-fatal) state and surface
+// a warning.
 func (bb *MeshBuildingBlockV2) IsWaitingForInput() bool {
 	return bb.Status.Status == BuildingBlockStatusWaitingForOperatorInput ||
 		bb.Status.Status == BuildingBlockStatusWaitingForUserInput ||
-		bb.Status.Status == BuildingBlockStatusWaitingForDependentInput
+		bb.Status.Status == BuildingBlockStatusWaitingForDependentInput ||
+		bb.Status.Status == BuildingBlockStatusWaitingForApproval
 }
 
 // bbUuidOrUnknown returns the building block UUID for diagnostic messages, or "<unknown>" if nil.

--- a/client/building_block_v2_test.go
+++ b/client/building_block_v2_test.go
@@ -136,6 +136,15 @@ func TestMeshBuildingBlockV2_CreateSuccessful(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "WAITING_FOR_APPROVAL — terminal but non-fatal",
+			bb: &MeshBuildingBlockV2{
+				Metadata: MeshBuildingBlockV2Metadata{Uuid: new("test-uuid")},
+				Status:   &MeshBuildingBlockV2Status{Status: BuildingBlockStatusWaitingForApproval},
+			},
+			wantDone: true,
+			wantErr:  false,
+		},
+		{
 			name: "FAILED with nil Uuid does not panic",
 			bb: &MeshBuildingBlockV2{
 				Metadata: MeshBuildingBlockV2Metadata{Uuid: nil},

--- a/docs/data-sources/building_block_v2.md
+++ b/docs/data-sources/building_block_v2.md
@@ -109,7 +109,7 @@ Read-Only:
 - `force_purge` (Boolean) Indicates whether an operator has requested purging of this Building Block.
 - `lifecycle` (Attributes) Lifecycle state of this building block. (see [below for nested schema](#nestedatt--status--lifecycle))
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
-- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
+- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 
 <a id="nestedatt--status--lifecycle"></a>
 ### Nested Schema for `status.lifecycle`

--- a/docs/data-sources/building_blocks.md
+++ b/docs/data-sources/building_blocks.md
@@ -54,7 +54,7 @@ data "meshstack_building_blocks" "all" {
 - `name` (String) Only return building blocks with this exact name.
 - `platform_identifier` (String) Only return building blocks on this platform (`<platformInstance>.<location>`).
 - `project_identifier` (String) Only return building blocks in this project.
-- `status` (String) Only return building blocks in this execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
+- `status` (String) Only return building blocks in this execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 - `target_kind` (String) Only return building blocks with this target kind. One of `meshTenant`, `meshWorkspace`.
 - `tenant_uuid` (String) Only return building blocks targeting the tenant with this UUID.
 - `version_number` (String) Only return building blocks created from this building block definition version number. Accepts a plain number (`1`) or a `v`-prefixed string (`v1`); the `v` is stripped server-side.
@@ -150,7 +150,7 @@ Read-Only:
 - `latest_dry_run_uuid` (String) UUID of the latest dry (DETECT) run, but only when it is the newest run; null otherwise.
 - `latest_run_uuid` (String) UUID of the latest modifying (apply/destroy) run. Null when none exists or when permissions are insufficient to read runs.
 - `outputs` (Attributes Map) Outputs of the building block, available after a successful run. (see [below for nested schema](#nestedatt--building_blocks--status--outputs))
-- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
+- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 
 <a id="nestedatt--building_blocks--status--outputs"></a>
 ### Nested Schema for `building_blocks.status.outputs`

--- a/docs/data-sources/buildingblock.md
+++ b/docs/data-sources/buildingblock.md
@@ -90,7 +90,7 @@ Read-Only:
 Read-Only:
 
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
-- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.
+- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/docs/resources/building_block.md
+++ b/docs/resources/building_block.md
@@ -232,7 +232,7 @@ Read-Only:
 - `latest_dry_run_uuid` (String) UUID of the latest dry (DETECT) run for this Building Block, but only when it is the newest run; null otherwise. Same permission gating as `latest_run_uuid`.
 - `latest_run_uuid` (String) UUID of the latest modifying (apply/destroy) run for this Building Block. Excludes dry runs (see `latest_dry_run_uuid`). Null when no modifying run exists, or when permissions are insufficient to read runs.
 - `outputs` (Attributes Map) Outputs of building block, available after a successful run. (see [below for nested schema](#nestedatt--status--outputs))
-- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
+- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/docs/resources/building_block_v2.md
+++ b/docs/resources/building_block_v2.md
@@ -164,7 +164,7 @@ Read-Only:
 - `force_purge` (Boolean) Indicates whether an operator has requested purging of this Building Block.
 - `lifecycle` (Attributes) Lifecycle state of this building block. (see [below for nested schema](#nestedatt--status--lifecycle))
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
-- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
+- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 
 <a id="nestedatt--status--lifecycle"></a>
 ### Nested Schema for `status.lifecycle`

--- a/docs/resources/buildingblock.md
+++ b/docs/resources/buildingblock.md
@@ -121,7 +121,7 @@ Read-Only:
 Read-Only:
 
 - `outputs` (Attributes Map) Building block outputs. Each output has exactly one value attribute set. (see [below for nested schema](#nestedatt--status--outputs))
-- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.
+- `status` (String) Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.
 
 <a id="nestedatt--status--outputs"></a>
 ### Nested Schema for `status.outputs`

--- a/internal/provider/building_block_resource.go
+++ b/internal/provider/building_block_resource.go
@@ -637,7 +637,7 @@ func addWaitingForInputWarning(diags *diag.Diagnostics, bb *client.MeshBuildingB
 		uuid = *bb.Metadata.Uuid
 	}
 	diags.AddWarning(
-		"Building block run is waiting for input",
+		"Building block run is waiting for input or approval",
 		fmt.Sprintf("Building block %s is in status %s. Resolve the pending input or approval in meshPanel to complete the run; outputs are not yet available.", uuid, bb.Status.Status),
 	)
 }

--- a/internal/provider/building_block_resource.go
+++ b/internal/provider/building_block_resource.go
@@ -638,7 +638,7 @@ func addWaitingForInputWarning(diags *diag.Diagnostics, bb *client.MeshBuildingB
 	}
 	diags.AddWarning(
 		"Building block run is waiting for input",
-		fmt.Sprintf("Building block %s is in status %s. Provide the required inputs in meshPanel to complete the run; outputs are not yet available.", uuid, bb.Status.Status),
+		fmt.Sprintf("Building block %s is in status %s. Resolve the pending input or approval in meshPanel to complete the run; outputs are not yet available.", uuid, bb.Status.Status),
 	)
 }
 

--- a/internal/provider/buildingblock_data_source.go
+++ b/internal/provider/buildingblock_data_source.go
@@ -107,7 +107,7 @@ func (d *buildingBlockDataSource) Schema(ctx context.Context, req datasource.Sch
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
 					"status": schema.StringAttribute{
-						MarkdownDescription: "Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.",
+						MarkdownDescription: "Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.",
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),

--- a/internal/provider/buildingblock_data_source.go
+++ b/internal/provider/buildingblock_data_source.go
@@ -107,7 +107,7 @@ func (d *buildingBlockDataSource) Schema(ctx context.Context, req datasource.Sch
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
 					"status": schema.StringAttribute{
-						MarkdownDescription: "Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.",
+						MarkdownDescription: "Execution status. One of " + client.BuildingBlockStatuses.Markdown() + ".",
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),

--- a/internal/provider/buildingblock_resource.go
+++ b/internal/provider/buildingblock_resource.go
@@ -152,7 +152,7 @@ func (r *buildingblockResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"status": schema.StringAttribute{
-						MarkdownDescription: "Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.",
+						MarkdownDescription: "Execution status. One of " + client.BuildingBlockStatuses.Markdown() + ".",
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),

--- a/internal/provider/buildingblock_resource.go
+++ b/internal/provider/buildingblock_resource.go
@@ -152,7 +152,7 @@ func (r *buildingblockResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"status": schema.StringAttribute{
-						MarkdownDescription: "Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`.",
+						MarkdownDescription: "Execution status. One of `WAITING_FOR_DEPENDENT_INPUT`, `WAITING_FOR_OPERATOR_INPUT`, `WAITING_FOR_USER_INPUT`, `WAITING_FOR_APPROVAL`, `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `ABORTED`.",
 						Computed:            true,
 					},
 					"outputs": buildingBlockOutputs(),


### PR DESCRIPTION
meshStack will soon add an approval gate that surfaces building block runs as WAITING_FOR_APPROVAL (added in meshfed, not released yet). The provider's await logic treats any status not in its BuildingBlockStatuses enum as fatal ("unknown building block status; provider may be out of date"), so once the backend starts returning it an awaited create/update would error when a run parked for approval.

Add WAITING_FOR_APPROVAL to the enum and to IsWaitingForInput() ahead of that rollout so it is treated as a non-terminal, non-fatal parked state: polling stops and a "waiting for input" warning is surfaced, matching the other WAITING_FOR_* states. Generalize the warning wording to cover approvals, complete the legacy v1 status doc strings, and regenerate docs.