### PR TITLE
fix(building_block_definition): send display_order 0 so it round-trips

### DIFF
--- a/client/building_block_definition_version.go
+++ b/client/building_block_definition_version.go
@@ -112,7 +112,10 @@ type MeshBuildingBlockDefinitionInput struct {
 	Description                 *string           `json:"description,omitempty" tfsdk:"description"`
 	ValueValidationRegex        *string           `json:"valueValidationRegex,omitempty" tfsdk:"value_validation_regex"`
 	ValidationRegexErrorMessage *string           `json:"validationRegexErrorMessage,omitempty" tfsdk:"validation_regex_error_message"`
-	DisplayOrder                int64             `json:"displayOrder,omitempty" tfsdk:"display_order"`
+	// No omitempty: a 0 (the schema default, and what an unknown plan value collapses to) must be sent so
+	// the backend stores it verbatim. With omitempty the 0 would be dropped and the backend would assign
+	// a position itself, making the applied value differ from the plan.
+	DisplayOrder int64 `json:"displayOrder" tfsdk:"display_order"`
 }
 
 func (m *MeshBuildingBlockDefinitionInput) UnmarshalJSON(bytes []byte) error {
@@ -149,7 +152,8 @@ type MeshBuildingBlockDefinitionOutput struct {
 	DisplayName    string                                          `json:"displayName" tfsdk:"display_name"`
 	Type           MeshBuildingBlockIOType                         `json:"type" tfsdk:"type"`
 	AssignmentType MeshBuildingBlockDefinitionOutputAssignmentType `json:"assignmentType" tfsdk:"assignment_type"`
-	DisplayOrder   int64                                           `json:"displayOrder,omitempty" tfsdk:"display_order"`
+	// No omitempty so a 0 is sent, not dropped (see MeshBuildingBlockDefinitionInput.DisplayOrder).
+	DisplayOrder int64 `json:"displayOrder" tfsdk:"display_order"`
 }
 
 // Main version types

--- a/internal/clientmock/mock_building_block_definition_version.go
+++ b/internal/clientmock/mock_building_block_definition_version.go
@@ -3,6 +3,7 @@ package clientmock
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/google/uuid"
 
@@ -77,8 +78,23 @@ func applyManualOutputBehavior(versionSpec *client.MeshBuildingBlockDefinitionVe
 			platformTenantIdKeys[key] = true
 		}
 	}
+	// Mirror the backend (ManualDefinitionVersionService.mapInputsToOutputUpdateModels): derived outputs
+	// take their display_order from the input's position in (display_order, key)-sorted order, NOT the
+	// input's own display_order. So two inputs both at display_order 0 yield outputs 0 and 1.
+	keys := make([]string, 0, len(versionSpec.Inputs))
+	for key := range versionSpec.Inputs {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if di, dj := versionSpec.Inputs[keys[i]].DisplayOrder, versionSpec.Inputs[keys[j]].DisplayOrder; di != dj {
+			return di < dj
+		}
+		return keys[i] < keys[j]
+	})
+
 	outputs := make(map[string]client.MeshBuildingBlockDefinitionOutput, len(versionSpec.Inputs))
-	for key, input := range versionSpec.Inputs {
+	for index, key := range keys {
+		input := versionSpec.Inputs[key]
 		assignmentType := client.MeshBuildingBlockDefinitionOutputAssignmentTypeNone.Unwrap()
 		if platformTenantIdKeys[key] {
 			assignmentType = client.MeshBuildingBlockDefinitionOutputAssignmentTypePlatformTenantID.Unwrap()
@@ -87,7 +103,7 @@ func applyManualOutputBehavior(versionSpec *client.MeshBuildingBlockDefinitionVe
 			DisplayName:    input.DisplayName,
 			Type:           translateManualInputTypeToOutput(input.Type),
 			AssignmentType: assignmentType,
-			DisplayOrder:   input.DisplayOrder,
+			DisplayOrder:   int64(index),
 		}
 	}
 	versionSpec.Outputs = outputs

--- a/internal/provider/building_block_definition_resource_model_test.go
+++ b/internal/provider/building_block_definition_resource_model_test.go
@@ -29,9 +29,9 @@ var (
 func Test_versionContentHash(t *testing.T) {
 	// If constant values below are required to change, you need a good reason and consider backwards compatibility!
 	const (
-		hashWhichShouldNeverChange1 = "djI6Njc0Yzc3YzI4ZTRlYjRjZWM5OWI5ZjFlNzNhZDExYjUyMGEzNjdkYTQxNmZmM2ZhOTBkNWU1NDI2ZTA5YmVmYw=="
-		hashWhichShouldNeverChange2 = "djI6MDIwY2Q3YzAzMmZmNmNlMDVhMDI4NzNmZDMxOWU3YjcyMDY4OTZmYTQxNTkwNDc5MTgzNmM5MzNmMGEyMzllZQ=="
-		hashWhichShouldNeverChange3 = "djI6MmI5OTJlMjM0MzE2YmFhMDhkMWY0ZDAxN2Y1NzM3OWRkZmI0NWYzOWYzYWU3YjE0ODA3OTMyMjkzOGRmZDhlMA=="
+		hashWhichShouldNeverChange1 = "djI6N2Y4NDNjY2I0YTUzYjY3OWUyNDVhYzkyODFiM2UyZTk1N2JlNjc0YWNjMGY0OGVmMWM3YjhjMmJhNTJmMzlhOA=="
+		hashWhichShouldNeverChange2 = "djI6ODFlNGU0MzZmMmUzNzMwZDBhNWUwZjJlYzY4NTcwZWM4OGNiN2Y4MmI5MzM1MGQ0ZTRkOTVkZTEyMDhkYTU3YQ=="
+		hashWhichShouldNeverChange3 = "djI6MWEyNGY3MGRlNjE3ZTY0ZmMyNThjZWNhNGE0YjcxNTllY2ViZDlhOTVhY2Q0ZWE0MDg1MWU0NDNjMDgwMDM4ZQ=="
 	)
 	require.NotEqual(t, hashWhichShouldNeverChange1, hashWhichShouldNeverChange2)
 	tests := []struct {

--- a/internal/provider/building_block_definition_resource_test.go
+++ b/internal/provider/building_block_definition_resource_test.go
@@ -425,22 +425,24 @@ func TestAccBuildingBlockDefinition(t *testing.T) {
       ticket   = { display_name = "Ticket", type = "STRING", assignment_type = "STATIC", argument = jsonencode("T-1") }
     }`)
 
-		outputCheck := func(displayName, ioType string) knownvalue.Check {
+		// Derived outputs inherit the backend's positional display_order (input order, 0-based): the manual
+		// output derivation assigns position = input index, see meshfed ManualDefinitionVersionService.
+		outputCheck := func(displayName, ioType string, displayOrder int64) knownvalue.Check {
 			return xknownvalue.MapExact(map[string]knownvalue.Check{
 				"display_name":    knownvalue.StringExact(displayName),
 				"type":            knownvalue.StringExact(ioType),
 				"assignment_type": knownvalue.StringExact("NONE"),
-				"display_order":   knownvalue.Int64Exact(0),
+				"display_order":   knownvalue.Int64Exact(displayOrder),
 			})
 		}
 		baseOutputs := knownvalue.MapExact(map[string]knownvalue.Check{
-			"approval": outputCheck("Approval", "BOOLEAN"),
-			"region":   outputCheck("Region", "STRING"),
+			"approval": outputCheck("Approval", "BOOLEAN", 0),
+			"region":   outputCheck("Region", "STRING", 1),
 		})
 		redraftOutputs := knownvalue.MapExact(map[string]knownvalue.Check{
-			"approval": outputCheck("Approval", "BOOLEAN"),
-			"region":   outputCheck("Region", "STRING"),
-			"ticket":   outputCheck("Ticket", "STRING"),
+			"approval": outputCheck("Approval", "BOOLEAN", 0),
+			"region":   outputCheck("Region", "STRING", 1),
+			"ticket":   outputCheck("Ticket", "STRING", 2),
 		})
 
 		releasedHashStable := statecheck.CompareValue(compare.ValuesSame())

--- a/internal/provider/building_block_definition_version_content_hash.go
+++ b/internal/provider/building_block_definition_version_content_hash.go
@@ -53,6 +53,25 @@ func calculateBuildingBlockDefinitionVersionContentHash(versionSpecDto client.Me
 		versionSpecDto.State = nil
 		versionSpecDto.BuildingBlockDefinitionRef = nil
 
+		// display_order is presentation-only, so normalize it out of the content hash: a reorder is not a
+		// content change. It is zeroed here rather than via omitempty on the DTO, because the DTO must
+		// serialize display_order (including 0) on the wire so the backend stores it verbatim instead of
+		// assigning a position itself. Clone the maps so we never mutate the caller's version spec.
+		strippedInputs := make(map[string]*client.MeshBuildingBlockDefinitionInput, len(versionSpecDto.Inputs))
+		for key, input := range versionSpecDto.Inputs {
+			clone := *input
+			clone.DisplayOrder = 0
+			strippedInputs[key] = &clone
+		}
+		versionSpecDto.Inputs = strippedInputs
+
+		strippedOutputs := make(map[string]client.MeshBuildingBlockDefinitionOutput, len(versionSpecDto.Outputs))
+		for key, output := range versionSpecDto.Outputs {
+			output.DisplayOrder = 0
+			strippedOutputs[key] = output
+		}
+		versionSpecDto.Outputs = strippedOutputs
+
 		// Converting it first from/to JSON makes hashing more stable, as fields with 'omitempty' are ignored.
 		// Additionally, all numbers are converted to float64, even integers (which also allows changing DTO model types later on).
 		// Also, the current Hasher implementation does not support structs for now, but map[string]any works!


### PR DESCRIPTION
## Problem

`main` acceptance CI is red across the suite (13 failures) with:

```
Error: Provider produced inconsistent result after apply
  .version_spec.outputs["…"].display_order: was cty.NumberIntVal(0), but now cty.NumberIntVal(1)
```

`display_order` (added in the unreleased v0.23.2, `46c496c`) was serialized with `json:"…,omitempty"`. The schema defaults it to `0` (and an unknown plan value collapses to `0` via `WithSetUnknownValueToZero`), but `omitempty` **drops a `0` from the request body**. The backend then assigns a position itself (`displayOrder ?: positional`), so the applied value differs from the planned `0`.

## Fix

- **client**: drop `omitempty` on input/output `DisplayOrder` (plain `int64`) so a `0` is sent and the backend stores it verbatim. A pointer does **not** work here: `WithSetUnknownValueToZero` collapses an unknown plan value to the pointer's zero (`nil`), which `omitempty` then drops — reintroducing the bug.
- **content hash**: normalize `display_order` to `0` before hashing (clone-safe), so presentation-only reordering is not a content change and the hash stays decoupled from the wire value. Golden hashes updated; the invariants (irrelevant-change → same hash, null vs empty outputs → same hash) still hold.
- **test** `07_manual_computed_outputs`: manual BBDs omit outputs; the backend derives them one-per-input with **positional** `display_order` in input order (0-based: approval=0, region=1, ticket=2), per meshfed `ManualDefinitionVersionService`. The old blanket `display_order=0` expectation was wrong.
- **mock**: derive manual-output `display_order` by input index to mirror the backend, so mock and acceptance runs stay in lock-step.

## Validation

Run against a local **develop** backend (the CI `:latest` image is also built from develop):

- `TestAccBuildingBlockDefinition` — all 11 subtests pass.
- `TestAccLandingZone` / `TestAccLandingZoneDataSource` pass (these exercise the shared `mandatory_bbd`, whose config-declared output was the source of the tenant/LZ/BB failures).
- `task test` (unit/mock) and `task lint` green.

The remaining previously-failing tests (`TestAccTenantV4*`, `TestAccBuildingBlockV2/02_tenant`, `TestAccBuildingBlock/*`) all failed at the same `mandatory_bbd`-create step, now fixed; their end-to-end paths need the replicator/runners (full CI stack).

> Note: the acceptance job is advisory on PRs (posts a comment) — it runs against the last-merged backend image; the gating signal is the push-to-`main` run.