### PR TITLE
ci: pin OpenTofu binary in unit test job to fix "text file busy" flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,12 +95,22 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      # The mock tests (TF_ACC unset -> IsUnitTest) still drive a real CLI. Left to auto-install one,
+      # the framework races parallel exec against its own download ("text file busy"/ETXTBSY, plus
+      # occasional 502s); pin a pre-installed tofu instead. Mirrors the acceptance job's pinning below.
+      - uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
+        with:
+          tofu_wrapper: false
       # Emit coverage as a binary coverage-data directory (GOCOVERDIR format) rather than a text
       # profile, so the acceptance job on a different runner can merge it with its own live-backend
       # coverage via `go tool covdata merge`. `-coverpkg=./...` attributes coverage across all
       # packages; the test binaries flush coverage on exit even when a test fails.
       - name: Run unit tests with gotestsum
+        env:
+          # OpenTofu resolves the test provider's legacy "-" namespace only against this host.
+          TF_ACC_PROVIDER_HOST: registry.opentofu.org
         run: |
+          export TF_ACC_TERRAFORM_PATH="$(command -v tofu)"
           mkdir -p covdata/unit
           go tool gotestsum --junitfile junit.xml --format testdox -- \
             -coverpkg=./... ./... -args -test.gocoverdir="$PWD/covdata/unit"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,14 @@ of duplicating (and drifting from) it:
 For any cross-cutting concern with no TF-repo skill, read the matching meshfed-release skill and
 apply its language-agnostic guidance to Go, ignoring Kotlin/JVM/Gradle specifics.
 
+## Code comments
+
+Applies to code, tests, and CI/workflow YAML alike. Keep comments lean: a comment earns its place
+only by saying what the code cannot — the *why*, a trade-off, a non-obvious constraint, or a
+surprise. Do not restate what a name, signature, or type already conveys. Prefer one sharp line
+over a paragraph. Full guidance lives in meshfed-release's `PRINCIPLES.md` + `AGENTS.md`
+"Code Comments".
+
 ## Key directories
 
 - **`internal/provider/`** — provider implementation (`provider.go`, `*_resource.go`, `*_data_source.go`).


### PR DESCRIPTION
## Problem

The `Go Test` (unit) job intermittently fails while setting up the terraform CLI. Two faces of the same root cause, seen back-to-back on the same commit:

```
fork/exec /tmp/plugintest-terraform<rand>/terraform: text file busy      # ETXTBSY
failed to find or install Terraform CLI from [...]: Unknown status: 502   # download flake
```

Each takes down ~15-20 tests at once.

## Root cause

The mock-backed tests run in the unit job via `ApplyAndTest` → `testCase.IsUnitTest = true` (`internal/provider/provider_test.go:87`) when `TF_ACC` is unset. `IsUnitTest` still drives a **real CLI** (which reattaches to the in-process mock provider).

The unit job had **no CLI in `PATH` and no `TF_ACC_TERRAFORM_PATH`**, so the plugin-testing framework installed one into a temp dir *at test time*. With tests running in parallel, one goroutine execs the binary while another is still writing it — Linux `execve()` returns `ETXTBSY` for any file open for writing. The same on-the-fly download is also exposed to registry hiccups (the 502).

It only reproduces in CI because locally a CLI is already in `PATH`, so the framework skips the download.

## Fix

Pre-install OpenTofu (`setup-opentofu`) and pin `TF_ACC_TERRAFORM_PATH` to it, with `TF_ACC_PROVIDER_HOST=registry.opentofu.org` — mirroring the acceptance job. The binary is static and fully written before any test runs, and nothing is downloaded during the run, so both failure modes are gone. **Parallelism is unchanged** — the race was the *write*, not the parallel reads.

CI-config only; no test or provider code changes. Verified locally: `go test ./internal/provider -run TestAccBuildingBlockDefinition -parallel 16` passes with `TF_ACC_TERRAFORM_PATH=$(command -v tofu)` + `TF_ACC_PROVIDER_HOST=registry.opentofu.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)