### PR TITLE
ci: gate acceptance tests instead of soft-failing on PRs

### DIFF
--- a/.agents/skills/github-ci/SKILL.md
+++ b/.agents/skills/github-ci/SKILL.md
@@ -46,10 +46,27 @@ All gated on `build` succeeding first.
 | `build` | `go mod tidy` then `go build`; fails if `go mod tidy` produces a diff (commit the tidy). |
 | `golangci` | `golangci-lint-action` with `only-new-issues: true` (annotates only changed code on PRs). On failure it prints the `golangci-lint run --fix` hint. |
 | `generate` | `go generate` then fails on any diff — regenerate docs (`task generate`) and commit. |
-| `test` | Runs tests via gotestsum and posts coverage. |
+| `test` | Unit/mock tests via gotestsum; posts coverage. Pins `TF_ACC_TERRAFORM_PATH` to a pre-installed tofu (`setup-opentofu`) — the mock tests still drive a real CLI, and auto-install races parallel exec against the download ("text file busy"). |
+| `acceptance` | `TestAcc` suite on self-hosted `mesh-runners` against the full backend (meshfed `:latest` service containers). **Gates merge** (PRs and push to main). tofu comes from the nix-ci image; a truncation guard reds an incomplete run as UNKNOWN (re-run). |
 
-`permissions` are minimal per job (`contents: read`; `test` adds `pull-requests: write` for the
-coverage comment, `golangci` adds `pull-requests: read` for `only-new-issues`).
+`permissions` are minimal per job (`contents: read`; `test`/`acceptance` add `pull-requests: write`
+for the coverage/PR comment, `golangci` adds `pull-requests: read` for `only-new-issues`).
+
+## Companion meshfed-release changes
+
+The `acceptance` job runs against the **last merged** meshfed-release backend — the `:latest`
+service-container images, which rebuild from develop on merge. So a provider change that needs a
+backend change fails acc here until the backend lands. That is the correct merge order, not a
+workaround:
+
+1. Open the companion PR in `meshfed-release` (same branch name). Its `terraform-provider-acceptance`
+   job builds the backend from source, pairs this provider branch, and validates the pair.
+2. Merge that PR → `:latest` rebuilds.
+3. Re-run this provider PR's acceptance job → it now runs against the rebuilt backend → green → merge.
+
+Never bypass a red acceptance check to merge provider-first: that ships a provider broken against the
+released backend. On failure the PR comment links a branch-filtered meshfed-release PR search (it
+404s for anyone without access to that private repo).
 
 ## Standard actions
 

--- a/.agents/skills/github-ci/SKILL.md
+++ b/.agents/skills/github-ci/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: github-ci
-description: Conventions for this repo's GitHub Actions workflows — pinning actions to full SHAs, updating action versions, the build/lint/generate/test jobs, and gotestsum coverage reporting. Use when editing .github/workflows/*.yml, bumping an action version, or debugging a CI job.
+description: Conventions for this repo's GitHub Actions workflows — pinning actions to full SHAs, updating action versions, the build/lint/generate/test/acceptance jobs, the companion meshfed-release merge order, and gotestsum coverage reporting. Use when editing .github/workflows/*.yml, bumping an action version, or debugging a CI job.
 ---
 
 # GitHub Actions CI conventions
 
 Workflows live in `.github/workflows/` (`test.yml`, `release.yml`). They follow the HashiCorp
 [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework)
-template with two adjustments: **no Terraform version matrix** (single version from
-`hashicorp/setup-terraform`) and a **separate `golangci` lint job** (not folded into build).
+template with adjustments: **no Terraform version matrix**, a **separate `golangci` lint job** (not
+folded into build), and **OpenTofu** as the test/acceptance CLI (Terraform is used only for doc
+generation).
 
 ## Action pinning (the main rule)
 
@@ -75,7 +76,8 @@ released backend. On failure the PR comment links a branch-filtered meshfed-rele
 | `actions/checkout` | Clone repo (the `test` job uses `fetch-depth: 0` for base-branch coverage comparison) |
 | `actions/setup-go` | Install Go (`go-version-file: go.mod`, or `stable` for the lint job) |
 | `golangci/golangci-lint-action` | Lint + format check with inline annotations |
-| `hashicorp/setup-terraform` | Install Terraform CLI for doc generation (`terraform_wrapper: false`) |
+| `hashicorp/setup-terraform` | Install Terraform CLI for the `generate` job only (`terraform_wrapper: false`) |
+| `opentofu/setup-opentofu` | Install OpenTofu for the `test` job; `TF_ACC_TERRAFORM_PATH` pins it (`tofu_wrapper: false`) |
 | `goreleaser/goreleaser-action` | Build + release binaries (release.yml) |
 | `crazy-max/ghaction-import-gpg` | Import GPG key for release signing (release.yml) |
 
@@ -84,7 +86,11 @@ released backend. On failure the PR comment links a branch-filtered meshfed-rele
 - Tests run through [gotestsum](https://github.com/gotestyourself/gotestsum), installed as a Go
   tool dependency in `go.mod` (`tool gotest.tools/gotestsum`); invoked as `go tool gotestsum`
   (version managed by Dependabot, gomod ecosystem).
-- Command: `go tool gotestsum --junitfile junit.xml --format testdox -- -coverprofile=coverage.out -coverpkg=./... ./...`
-  — `-coverpkg=./...` gives accurate cross-package coverage.
-- Coverage total + by-file detail go to `GITHUB_STEP_SUMMARY`; on PRs the summary is posted/updated
-  as a comment via `gh pr comment … --edit-last` (official GitHub CLI, no third-party action).
+- Both test jobs emit **binary coverage data** (GOCOVERDIR), not a text profile — via
+  `-args -test.gocoverdir=…` with `-coverpkg=./...` for cross-package attribution: the `test` job
+  writes `covdata/unit`, the `acceptance` job writes `covdata/acc`.
+- `covdata/unit` is uploaded as an artifact so the `acceptance` job (a different, self-hosted runner)
+  downloads it and merges both with `go tool covdata` into one figure.
+- A single PR comment (matched by an HTML marker) is written by `.github/scripts/coverage-comment.sh`
+  in two stages: `unit` (Go Test job — unit figure, combined pending) then `combined` (acceptance job
+  — rewrites it with the merged figure). Safe when a job produced no data (reports `n/a`).

--- a/.github/scripts/coverage-comment.sh
+++ b/.github/scripts/coverage-comment.sh
@@ -94,7 +94,7 @@ if [ "$MODE" = combined ]; then
         success) ACC_TAG=" — ✅ acceptance passed" ;;
         failure)
           ACC_TAG=" — ❌ acceptance failed"
-          ACC_NOTE="❌ **Acceptance tests failed** (advisory — the job runs against the last *merged* meshfed-release backend, so a change needing a companion backend PR fails here until that backend merges; the real gate is meshfed-release's \`terraform-provider-acceptance\` job)."
+          ACC_NOTE="❌ **Acceptance tests failed** — this blocks merge. If the change needs a companion backend change, merge its meshfed-release PR first (rebuilds \`:latest\`), then re-run; otherwise it is a regression to fix. See the acceptance comment for details."
           ;;
       esac
       ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,23 +186,33 @@ jobs:
           RABBITMQ_DEFAULT_USER: guest
           RABBITMQ_DEFAULT_PASS: guest
 
+      # Cap each JVM service container's heap. The ARC $job-pod hook injects a JAVA_TOOL_OPTIONS -Xmx
+      # only into the job container, not service containers, so an uncapped JVM here sizes its heap to
+      # ~25% of node memory; several at once overcommit the spot node and OOM-kill it — surfacing as a
+      # truncated ("did not complete") acc run. Mirrors meshfed-release's service-container caps.
       keycloak:
         image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/keycloak-ci:26
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx1g
 
       meshfed-api:
         image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/meshfed:latest
         env:
           SERVER_PORT: "8089"   # off 8080 so the tf-runner health server can have it; mgmt 8180
+          JAVA_TOOL_OPTIONS: -Xmx2g   # heap cap (working set ~1.4Gi), see keycloak
         options: --restart on-failure
 
       replicator:
         image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/replicator:latest
         env:
           SERVER_PORT: "7080"   # move embedded server off 8080; mgmt 7180
+          JAVA_TOOL_OPTIONS: -Xmx2g   # heap cap, see keycloak
         options: --restart on-failure
 
       block-coordinator-api:
         image: ${{ vars.MESHFED_REGISTRY }}/meshstack-container/block-coordinator-api:latest
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx2g   # heap cap, see keycloak
         options: --restart on-failure
 
       # Single poller of the magic runner UUID; fans work out by type. 127.0.0.1 forces IPv4 (the Go
@@ -232,6 +242,7 @@ jobs:
           RUNNER_UUID: 11111111-1111-1111-1111-111111111111
           RUNNER_API_CLIENT_ID: ${{ secrets.RUNNER_API_CLIENT_ID }}
           RUNNER_API_CLIENT_SECRET: ${{ secrets.RUNNER_API_CLIENT_SECRET }}
+          JAVA_TOOL_OPTIONS: -Xmx1g   # heap cap, see keycloak
         options: --restart on-failure
 
       manual-block-runner:
@@ -242,6 +253,7 @@ jobs:
           RUNNER_API_CLIENT_ID: ${{ secrets.RUNNER_API_CLIENT_ID }}
           RUNNER_API_CLIENT_SECRET: ${{ secrets.RUNNER_API_CLIENT_SECRET }}
           SERVER_PORT: "8104"   # move its embedded web server off 8080
+          JAVA_TOOL_OPTIONS: -Xmx1g   # heap cap, see keycloak
         options: --restart on-failure
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,16 +286,11 @@ jobs:
 
       - name: Run acceptance tests with coverage
         id: acc
-        # Advisory ON PRs ONLY: a failed acceptance run must never block a PR, because the job runs
-        # against the last *merged* meshfed-release backend images, so a change needing a companion
-        # backend PR cannot go green here until that backend merges — gating on it would deadlock
-        # cross-repo changes. On PRs, meshfed-release's source-built `terraform-provider-acceptance`
-        # job is the real gate and failures here only surface via an advisory comment (see the last
-        # step). On a push to main (and manual dispatch) there is no PR to comment on and the backend
-        # images are already merged, so the run is NOT advisory: a failure reds the job, surfacing a
-        # provider/backend regression here before a release tag — which is what this CI run would
-        # otherwise only catch in meshfed-release.
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        # Gates merge (PRs and push to main). The job runs against the last *merged* meshfed-release
+        # backend (`:latest` service containers), so a change needing a companion backend PR fails here
+        # until that PR merges and `:latest` rebuilds — the correct order, not a deadlock: merge the
+        # backend PR first (its terraform-provider-acceptance job pairs this branch), then re-run this
+        # job. See the github-ci skill "Companion meshfed-release changes"; the failure comment links it.
         env:
           # The acceptance API key/secret (seeded by the mariadb-ci dev dump) come from repo secrets.
           MESHSTACK_ENDPOINT: http://localhost:8089
@@ -323,13 +318,11 @@ jobs:
             -coverpkg=./... -count=1 -timeout 10m -run 'TestAcc' ./... \
             -args -test.gocoverdir="$PWD/covdata/acc" 2>&1 | tee acc-output.log
 
-      # Guard against the self-hosted runner truncating/killing the test process while the step above
-      # still reports success (seen here, and in meshfed-release's e2e job). gotestsum prints a final
-      # "DONE N tests ... in Xs" summary only when the run completes, so its absence means the run was
-      # cut short and the result is UNKNOWN — fail hard so it can never be mistaken for green. This is
-      # distinct from an advisory test failure: a completed run (DONE present) keeps `continue-on-error`
-      # semantics below; only an incomplete run reds the job and demands a re-run. Exposes `complete`
-      # for the coverage/advisory steps. Sets the output before exiting so they can still read it.
+      # Distinguish a truncated run from a real failure. gotestsum prints a final "DONE N tests ..."
+      # summary only when the run completes; its absence means the self-hosted runner cut the process
+      # short, so the result is UNKNOWN (re-run — likely runner-infra) rather than a genuine failure.
+      # Both red the job (the acc step already gates), but the advisory comment words itself per
+      # `complete`. Exposes `complete` for the coverage/advisory steps; sets it before exiting.
       - name: Verify acceptance run completed
         id: acccheck
         if: ${{ always() }}
@@ -359,10 +352,10 @@ jobs:
         shell: bash
         run: .github/scripts/coverage-comment.sh combined
 
-      # Advisory PR comment: the acceptance result never blocks (continue-on-error above). Post a
-      # comment when the latest run failed so the regression stays visible, and delete it once a later
-      # run goes green. Idempotent via the HTML marker; only on PRs (needs a PR number).
-      - name: Manage acceptance advisory comment
+      # PR comment: the acceptance result blocks merge, so this comment explains *why* it failed and how
+      # to unblock (see the failure branch), and deletes itself once a later run goes green. Idempotent
+      # via the HTML marker; only on PRs (needs a PR number).
+      - name: Manage acceptance PR comment
         if: ${{ always() && github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -373,6 +366,7 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          HEAD_REF: ${{ github.head_ref }}
         shell: bash
         run: |
           set -euo pipefail
@@ -386,6 +380,12 @@ jobs:
           JOB_URL=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
             --jq ".jobs[] | select(.runner_name == \"${RUNNER_NAME:-}\") | .html_url" 2>/dev/null | head -n1 || true)
           [ -n "$JOB_URL" ] || JOB_URL="$RUN_URL"
+
+          # Best-effort link to a same-branch companion PR in the (private) meshfed-release repo. This
+          # public repo's token cannot query that repo, so we build a branch-filtered PR search URL by
+          # convention rather than confirming one exists — it resolves for authorized users and 404s
+          # for everyone else.
+          MESHFED_PR_SEARCH="$SERVER_URL/meshcloud/meshfed-release/pulls?q=is%3Apr+head%3A${HEAD_REF}"
 
           existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
             --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -n1 || true)
@@ -421,8 +421,8 @@ jobs:
               ;;
             failure)
               upsert "$(printf '%s\n%s\n\n%s' "$MARKER" \
-                "⚠️ **Acceptance tests failed on the latest run.** This is advisory and does **not** block merge — the job runs against the last merged meshfed-release backend images. If this change needs a companion backend change, validate the pair via meshfed-release's \`terraform-provider-acceptance\` job; otherwise this is a regression to fix." \
-                "🔗 [View the failing acceptance job]($JOB_URL)")"
+                "❌ **Acceptance tests failed — this blocks merge.** The job runs against the last *merged* meshfed-release backend (\`:latest\`). If this change needs a companion backend change, get its meshfed-release PR green and **merged first** (that rebuilds \`:latest\`), then **re-run this job**; otherwise it is a regression to fix. Measured coverage for this run is in the coverage comment above." \
+                "🔗 [Failing acceptance job]($JOB_URL) · [companion meshfed-release PR — same branch]($MESHFED_PR_SEARCH) (private; 404 without access)")"
               ;;
             *)
               echo "acceptance outcome '$OUTCOME' — leaving any existing comment untouched"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,9 @@ versioning policy and format.
 
 GitHub Actions workflows pin every action to a full 40-char SHA with a `# vX.Y.Z` comment —
 never mutable tags. Full conventions (jobs, update procedure, action table, gotestsum coverage)
-are in the **`github-ci`** skill.
+are in the **`github-ci`** skill. The acceptance job **gates** merge and runs against the
+last-merged meshfed-release backend, so a change needing a companion backend PR must merge that PR
+first, then re-run — see that skill's "Companion meshfed-release changes".
 
 ## Adding a new resource
 


### PR DESCRIPTION
## Problem

The acceptance job ran with `continue-on-error` on PRs. A **completed** test failure only surfaced as an advisory comment while the check stayed **green** — so a real regression could merge unnoticed, indistinguishable from a benign backend-pending failure.

## Change

Make the acceptance result **gate merge on PRs** too (push-to-main already gated) — just remove the PR-only `continue-on-error`.

A provider change that needs a companion backend change fails against the last-**merged** meshfed-release `:latest` images until that PR lands. That's the **correct merge order, not a deadlock**:

1. Open the companion `meshfed-release` PR (same branch). Its `terraform-provider-acceptance` job builds the backend from source, pairs this provider branch, and validates the pair.
2. Merge it → `:latest` rebuilds from develop.
3. Re-run this PR's acceptance job → runs against the rebuilt backend → green → merge.

No bypass needed — and merging provider-first when acc is red would ship a provider broken against the released backend.

### PR comment
Reworked the failure comment to say it **blocks**, spell out that merge order, and link a branch-filtered `meshfed-release` PR search (`?q=is:pr+head:<branch>`). The public provider repo can't query the private backend repo, so the link is by convention and 404s for users without access. Measured coverage still posts via the existing coverage comment. The truncation guard (incomplete run = UNKNOWN, re-run) is unchanged.

### Docs
Documented the acceptance job and the companion merge order in the `github-ci` skill (new "Companion meshfed-release changes" section) and a pointer in `AGENTS.md`.

CI-config + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)