### PR TITLE
refactor: rename MESHSTACK_TENANT_ID assignment type to MESHSTACK_TENANT_UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ FEATURES:
 - `meshstack_building_block_definition`: `version_spec.inputs` now support the `MESHSTACK_TENANT_UUID` assignment type, which assigns the meshTenant's UUID as a string. Like `PLATFORM_TENANT_ID`, it takes no `argument`, `default_value`, or `sensitive` value.
 
 NOTES:
-- This assignment type is named `MESHSTACK_TENANT_UUID`. It was briefly called `MESHSTACK_TENANT_ID` in pre-release development builds (never in a tagged release), and was renamed to `MESHSTACK_TENANT_UUID` because the value it assigns is the meshTenant's UUID. This is a breaking rename of the wire value for anyone who tried the pre-release name: update any `assignment_type = "MESHSTACK_TENANT_ID"` to `assignment_type = "MESHSTACK_TENANT_UUID"`.
+- The assignment type introduced above was named `MESHSTACK_TENANT_ID` during development but was never part of a tagged release. It ships for the first time here as `MESHSTACK_TENANT_UUID`. If you pinned a pre-release build, update any `assignment_type = "MESHSTACK_TENANT_ID"` to `assignment_type = "MESHSTACK_TENANT_UUID"`.
 
 FIXES:
 - `meshstack_building_block_definition`: `display_order` on `version_spec.inputs` and `version_spec.outputs` again counts towards a version's computed `content_hash`. Changing only `display_order` on a draft does not really need to rerun the building block, but hashing it keeps the backend simpler and the provider follows the same rule. The `content_hash` version was raised from 2 to 3 to go with this change. A `content_hash` written by an older provider is now recomputed at the current version instead of being treated as changed, so upgrading no longer shows false plan diffs or reruns building blocks whose definition is already released.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 FEATURES:
 - `meshstack_building_block_definition`: `version_spec.inputs` now support the `MESHSTACK_TENANT_UUID` assignment type, which assigns the meshTenant's UUID as a string. Like `PLATFORM_TENANT_ID`, it takes no `argument`, `default_value`, or `sensitive` value.
 
-NOTES:
-- The assignment type introduced above was named `MESHSTACK_TENANT_ID` during development but was never part of a tagged release. It ships for the first time here as `MESHSTACK_TENANT_UUID`. If you pinned a pre-release build, update any `assignment_type = "MESHSTACK_TENANT_ID"` to `assignment_type = "MESHSTACK_TENANT_UUID"`.
-
 FIXES:
 - `meshstack_building_block_definition`: `display_order` on `version_spec.inputs` and `version_spec.outputs` again counts towards a version's computed `content_hash`. Changing only `display_order` on a draft does not really need to rerun the building block, but hashing it keeps the backend simpler and the provider follows the same rule. The `content_hash` version was raised from 2 to 3 to go with this change. A `content_hash` written by an older provider is now recomputed at the current version instead of being treated as changed, so upgrading no longer shows false plan diffs or reruns building blocks whose definition is already released.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # v0.23.3
 
 FEATURES:
-- `meshstack_building_block_definition`: `version_spec.inputs` now support the `MESHSTACK_TENANT_ID` assignment type, which assigns the meshTenant's UUID as a string. Like `PLATFORM_TENANT_ID`, it takes no `argument`, `default_value`, or `sensitive` value.
+- `meshstack_building_block_definition`: `version_spec.inputs` now support the `MESHSTACK_TENANT_UUID` assignment type, which assigns the meshTenant's UUID as a string. Like `PLATFORM_TENANT_ID`, it takes no `argument`, `default_value`, or `sensitive` value.
+
+NOTES:
+- This assignment type is named `MESHSTACK_TENANT_UUID`. It was briefly called `MESHSTACK_TENANT_ID` in pre-release development builds (never in a tagged release), and was renamed to `MESHSTACK_TENANT_UUID` because the value it assigns is the meshTenant's UUID. This is a breaking rename of the wire value for anyone who tried the pre-release name: update any `assignment_type = "MESHSTACK_TENANT_ID"` to `assignment_type = "MESHSTACK_TENANT_UUID"`.
 
 FIXES:
 - `meshstack_building_block_definition`: `display_order` on `version_spec.inputs` and `version_spec.outputs` again counts towards a version's computed `content_hash`. Changing only `display_order` on a draft does not really need to rerun the building block, but hashing it keeps the backend simpler and the provider follows the same rule. The `content_hash` version was raised from 2 to 3 to go with this change. A `content_hash` written by an older provider is now recomputed at the current version instead of being treated as changed, so upgrading no longer shows false plan diffs or reruns building blocks whose definition is already released.

--- a/client/building_block_definition_version.go
+++ b/client/building_block_definition_version.go
@@ -59,7 +59,7 @@ var (
 	MeshBuildingBlockInputAssignmentTypePlatformOperatorManualInput = MeshBuildingBlockInputAssignmentTypes.Entry("PLATFORM_OPERATOR_MANUAL_INPUT")
 	MeshBuildingBlockInputAssignmentTypeBuildingBlockOutput         = MeshBuildingBlockInputAssignmentTypes.Entry("BUILDING_BLOCK_OUTPUT")
 	MeshBuildingBlockInputAssignmentTypePlatformTenantID            = MeshBuildingBlockInputAssignmentTypes.Entry("PLATFORM_TENANT_ID")
-	MeshBuildingBlockInputAssignmentTypeMeshstackTenantId           = MeshBuildingBlockInputAssignmentTypes.Entry("MESHSTACK_TENANT_ID")
+	MeshBuildingBlockInputAssignmentTypeMeshstackTenantUuid         = MeshBuildingBlockInputAssignmentTypes.Entry("MESHSTACK_TENANT_UUID")
 	MeshBuildingBlockInputAssignmentTypeWorkspaceIdentifier         = MeshBuildingBlockInputAssignmentTypes.Entry("WORKSPACE_IDENTIFIER")
 	MeshBuildingBlockInputAssignmentTypeProjectIdentifier           = MeshBuildingBlockInputAssignmentTypes.Entry("PROJECT_IDENTIFIER")
 	MeshBuildingBlockInputAssignmentTypeFullPlatformIdentifier      = MeshBuildingBlockInputAssignmentTypes.Entry("FULL_PLATFORM_IDENTIFIER")

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -563,7 +563,7 @@ Optional:
 
 Required:
 
-- `assignment_type` (String) How the input value is assigned. One of `AUTHOR`, `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, `BUILDING_BLOCK_OUTPUT`, `PLATFORM_TENANT_ID`, `MESHSTACK_TENANT_ID`, `WORKSPACE_IDENTIFIER`, `PROJECT_IDENTIFIER`, `FULL_PLATFORM_IDENTIFIER`, `TENANT_BUILDING_BLOCK_UUID`, `STATIC`, `USER_PERMISSIONS`. Determines which additional attributes are required or allowed.
+- `assignment_type` (String) How the input value is assigned. One of `AUTHOR`, `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, `BUILDING_BLOCK_OUTPUT`, `PLATFORM_TENANT_ID`, `MESHSTACK_TENANT_UUID`, `WORKSPACE_IDENTIFIER`, `PROJECT_IDENTIFIER`, `FULL_PLATFORM_IDENTIFIER`, `TENANT_BUILDING_BLOCK_UUID`, `STATIC`, `USER_PERMISSIONS`. Determines which additional attributes are required or allowed.
 - `display_name` (String) Human-readable display name for the input.
 - `type` (String) Data type of the input. One of `STRING`, `CODE`, `INTEGER`, `BOOLEAN`, `FILE`, `LIST`, `SINGLE_SELECT`, `MULTI_SELECT`. `LIST` is deprecated, use `CODE` instead. For type `FILE`, the value must be a MIME-typed base64 data blob. Use `provider::meshstack::load_file` or `provider::meshstack::encode_file` to produce such a data blob. When providing this value via `argument` or `default_value`, wrap the blob in `jsonencode(...)`, for example `argument = jsonencode(provider::meshstack::load_file(...))`.
 


### PR DESCRIPTION
## Rename `MESHSTACK_TENANT_ID` → `MESHSTACK_TENANT_UUID`

Mechanical rename of the recently introduced `meshstack_building_block_definition` input assignment type. The value it assigns is the meshTenant's **UUID**, so the `_UUID` suffix is the accurate name.

- `client/`: enum entry `MeshBuildingBlockInputAssignmentTypeMeshstackTenantUuid` + wire value `MESHSTACK_TENANT_UUID`
- `docs/`: regenerated assignment-type list
- `CHANGELOG.md`: the pending v0.23.3 FEATURES entry now names `MESHSTACK_TENANT_UUID` directly

**Never released:** the assignment type only exists in the still-untagged `v0.23.3` section, so no tagged provider release ever exposed `MESHSTACK_TENANT_ID`. It ships for the first time as `MESHSTACK_TENANT_UUID`. No `TerraformProviderVersionRequirements` handshake is needed because no released provider version supported this assignment type.

Verification left to CI — the change is mechanical.

## Cross-repo PRs

- meshcloud/meshfed-release#10393 — companion backend + panel rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)