### PR TITLE
feat!: move building block definition resources to the GA v1 media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Requires meshStack 2026.29.0 or later (previously 2026.24.0).
 
 BREAKING CHANGES:
 - Release binaries are now published only for `linux` and `darwin` on `amd64` and `arm64`. Builds for `windows`, `freebsd`, `386` and 32-bit `arm` are no longer produced.
+- The `meshstack_building_block_definition` resource and data sources now use the GA `application/vnd.meshcloud.api.meshbuildingblockdefinition.v1.hal+json` media type (and the version sibling) instead of v1-preview, and the preview disclaimers were removed. This requires a meshStack release where the meshBuildingBlockDefinition v1 API is GA. (Behaviourally identical to v0.23.2, which used the preview media type of the same shape.) **Note: `client/client.go` MinMeshStackVersion must be bumped to the BBD-GA meshStack release before this PR merges.**
 
 FEATURES:
 - `meshstack_building_block_definition`: `version_spec.dependency_refs` now use the `dependencyDefinitionRefs` field (`{uuid, kind}`) instead of the deprecated `dependencyDefinitionUuids` (bare UUID array), so a dependency's `kind` round-trips. The resource schema is unchanged (no config or state migration). Upgrade **before** the backend removes `dependencyDefinitionUuids`, otherwise dependencies silently stop round-tripping. Content-hash bumped (to v5 in this release, together with the manual-outputs fix below); an older `content_hash` is recomputed rather than flagged changed, as in the v0.23.2 fix.

--- a/client/building_block_definition.go
+++ b/client/building_block_definition.go
@@ -72,7 +72,7 @@ type meshBuildingBlockDefinitionClient struct {
 
 func newBuildingBlockDefinitionClient(ctx context.Context, httpClient internal.HttpClient) MeshBuildingBlockDefinitionClient {
 	return meshBuildingBlockDefinitionClient{
-		meshObject: internal.NewMeshObjectClient[MeshBuildingBlockDefinition](ctx, httpClient, "v1-preview"),
+		meshObject: internal.NewMeshObjectClient[MeshBuildingBlockDefinition](ctx, httpClient, "v1"),
 	}
 }
 

--- a/client/building_block_definition_version.go
+++ b/client/building_block_definition_version.go
@@ -194,7 +194,7 @@ type meshBuildingBlockDefinitionVersionClient struct {
 
 func newBuildingBlockDefinitionVersionClient(ctx context.Context, httpClient internal.HttpClient) MeshBuildingBlockDefinitionVersionClient {
 	return meshBuildingBlockDefinitionVersionClient{
-		meshObject: internal.NewMeshObjectClient[MeshBuildingBlockDefinitionVersion](ctx, httpClient, "v1-preview"),
+		meshObject: internal.NewMeshObjectClient[MeshBuildingBlockDefinitionVersion](ctx, httpClient, "v1"),
 	}
 }
 

--- a/docs/data-sources/building_block_definitions.md
+++ b/docs/data-sources/building_block_definitions.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   List building block definitions with optional workspace filter. Prefer this plural data source with one(...) for reusable wiring in examples. For each returned definition, this data source performs an additional API call to load all versions; use workspace_identifier to narrow scope where possible.
   Cross-Workspace Access: When accessing building block definitions from workspaces other than your own using a workspace-scoped API key, the content_hash attribute will be null as it requires detailed version information that is not accessible without workspace permissions. The versions, version_latest, and version_latest_release attributes will still be populated with uuid, number, and state.
-  ~> Preview: This resource is in preview. Breaking changes are possible without prior notice due to changes in the underlying meshStack preview API https://docs.meshcloud.io/api/technical-specifications#preview-endpoints or due to changes in this provider. Please ensure you are running the latest version of the provider and report any bugs via GitHub issues https://github.com/meshcloud/terraform-provider-meshstack/issues or via support@meshcloud.io.
 ---
 
 # meshstack_building_block_definitions (Data Source)
@@ -13,10 +12,6 @@ description: |-
 List building block definitions with optional workspace filter. Prefer this plural data source with `one(...)` for reusable wiring in examples. For each returned definition, this data source performs an additional API call to load all versions; use `workspace_identifier` to narrow scope where possible. 
 
 **Cross-Workspace Access**: When accessing building block definitions from workspaces other than your own using a workspace-scoped API key, the `content_hash` attribute will be null as it requires detailed version information that is not accessible without workspace permissions. The `versions`, `version_latest`, and `version_latest_release` attributes will still be populated with uuid, number, and state.
-
-
-
-~> **Preview:** This resource is in preview. Breaking changes are possible without prior notice due to changes in the underlying [meshStack preview API](https://docs.meshcloud.io/api/technical-specifications#preview-endpoints) or due to changes in this provider. Please ensure you are running the latest version of the provider and report any bugs via [GitHub issues](https://github.com/meshcloud/terraform-provider-meshstack/issues) or via support@meshcloud.io.
 
 ## Example Usage
 

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -4,14 +4,11 @@ page_title: "meshstack_building_block_definition Resource - terraform-provider-m
 subcategory: ""
 description: |-
   Manages a meshBuildingBlockDefinition in meshStack. Building Block Definitions define reusable automation components that can be executed on workspaces or tenants. This resource combines the building block definition metadata with version information in a single resource for simplified management.
-  ~> Preview: This resource is in preview. Breaking changes are possible without prior notice due to changes in the underlying meshStack preview API https://docs.meshcloud.io/api/technical-specifications#preview-endpoints or due to changes in this provider. Please ensure you are running the latest version of the provider and report any bugs via GitHub issues https://github.com/meshcloud/terraform-provider-meshstack/issues or via support@meshcloud.io.
 ---
 
 # meshstack_building_block_definition (Resource)
 
 Manages a meshBuildingBlockDefinition in meshStack. Building Block Definitions define reusable automation components that can be executed on workspaces or tenants. This resource combines the building block definition metadata with version information in a single resource for simplified management.
-
-~> **Preview:** This resource is in preview. Breaking changes are possible without prior notice due to changes in the underlying [meshStack preview API](https://docs.meshcloud.io/api/technical-specifications#preview-endpoints) or due to changes in this provider. Please ensure you are running the latest version of the provider and report any bugs via [GitHub issues](https://github.com/meshcloud/terraform-provider-meshstack/issues) or via support@meshcloud.io.
 
 ## Example Usage
 

--- a/internal/provider/building_block_definition_resource_schema.go
+++ b/internal/provider/building_block_definition_resource_schema.go
@@ -230,8 +230,7 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a meshBuildingBlockDefinition in meshStack. " +
 			"Building Block Definitions define reusable automation components that can be executed on workspaces or tenants. " +
-			"This resource combines the building block definition metadata with version information in a single resource for simplified management." +
-			previewDisclaimer(),
+			"This resource combines the building block definition metadata with version information in a single resource for simplified management.",
 
 		Attributes: map[string]schema.Attribute{
 			"metadata": schema.SingleNestedAttribute{

--- a/internal/provider/building_block_definitions_data_source.go
+++ b/internal/provider/building_block_definitions_data_source.go
@@ -100,8 +100,7 @@ func (d *buildingBlockDefinitionsDataSource) Schema(_ context.Context, _ datasou
 			"**Cross-Workspace Access**: When accessing building block definitions from workspaces other than your own " +
 			"using a workspace-scoped API key, the `content_hash` attribute will be null as it requires detailed version " +
 			"information that is not accessible without workspace permissions. The `versions`, `version_latest`, and " +
-			"`version_latest_release` attributes will still be populated with uuid, number, and state." +
-			"\n\n" + previewDisclaimer(),
+			"`version_latest_release` attributes will still be populated with uuid, number, and state.",
 		Attributes: map[string]schema.Attribute{
 			"workspace_identifier": schema.StringAttribute{
 				MarkdownDescription: "Optional workspace identifier filter (maps to `ownedByWorkspace` query param).",


### PR DESCRIPTION
## What

Flips the `meshstack_building_block_definition` resource + data sources (and the version sibling) from the `v1-preview` media type to **GA `v1`**, and drops the preview disclaimers. Docs regenerated. This is now a **pure media-type flip** — the dependency-refs migration that used to ride on top of this PR was split out into #246 and is already on `main`.

## Status: prepared, held on the companion backend PR

Rebased onto `main` (2026-07-23); the redundant refs commit self-dropped (its content landed via #246, and `main`'s content-hash is now v5 after the manual-outputs fix). Green locally: `go build`, `task test`, `task lint` (0 issues), `task generate` (no docs drift).

**Not mergeable yet — needs the GA backend.** This PR makes the provider request the GA `v1` BBD media type, which only exists once **meshfed-release #10412** (still open) merges to `develop` and ships in a meshStack release. Until then:
- `Go Acceptance Test` will fail (the current develop/released backend, `2026.29.0`, serves only `v1-preview` for BBD — a `v1` request 406s).
- `client/client.go` `MinMeshStackVersion` (currently `2026.29.0`, inherited from #246) **must be bumped to the GA release** before merge; the CHANGELOG entry must move to the then-current pending section.

## Merge sequence

meshfed #10412 → `develop` → GA image builds/releases → set this PR's `MinMeshStackVersion` to that release → acceptance re-runs green → merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)