### PR TITLE
feat: send building block definition dependencies as dependencyDefinitionRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # v0.24.1
 
+Requires meshStack 2026.29.0 or later (previously 2026.24.0).
+
 BREAKING CHANGES:
 - Release binaries are now published only for `linux` and `darwin` on `amd64` and `arm64`. Builds for `windows`, `freebsd`, `386` and 32-bit `arm` are no longer produced.
+
+FEATURES:
+- `meshstack_building_block_definition`: `version_spec.dependency_refs` now use the `dependencyDefinitionRefs` field (`{uuid, kind}`) instead of the deprecated `dependencyDefinitionUuids` (bare UUID array), so a dependency's `kind` round-trips. The resource schema is unchanged (no config or state migration). Upgrade **before** the backend removes `dependencyDefinitionUuids`, otherwise dependencies silently stop round-tripping. Content-hash bumped to v4 (v3 taken by the `display_order` change below); an older `content_hash` is recomputed rather than flagged changed, as in the v0.23.2 fix.
 
 FIXES:
 - `meshstack_building_block_definition`: a manual building block with an explicit empty `version_spec.outputs = {}` is now rejected at plan time with a clear message telling you to omit the attribute, instead of failing at apply with "provider produced inconsistent result after apply: new element ... has appeared". Manual building blocks derive one output per input on the backend, so an explicit empty map can never match the applied result; omitting `version_spec.outputs` lets it be computed ([#240](https://github.com/meshcloud/terraform-provider-meshstack/issues/240)).

--- a/client/building_block_definition_version.go
+++ b/client/building_block_definition_version.go
@@ -153,7 +153,6 @@ type MeshBuildingBlockDefinitionVersionMetadata struct {
 	CreatedOn        string `json:"createdOn"`
 }
 
-type BuildingBlockDependencyRef string
 type MeshBuildingBlockDefinitionVersionSpec struct {
 	BuildingBlockDefinitionRef *UuidRef                                     `json:"buildingBlockDefinitionRef" tfsdk:"-"`
 	OnlyApplyOncePerTenant     bool                                         `json:"onlyApplyOncePerTenant" tfsdk:"only_apply_once_per_tenant"`
@@ -163,9 +162,10 @@ type MeshBuildingBlockDefinitionVersionSpec struct {
 	VersionNumber              *int64                                       `json:"versionNumber,omitempty" tfsdk:"version_number"`
 	State                      *MeshBuildingBlockDefinitionVersionState     `json:"state,omitempty" tfsdk:"state"`
 	RunnerRef                  *UuidRef                                     `json:"runnerRef" tfsdk:"runner_ref"`
-	DependencyDefinitionUUIDs  types.Set[BuildingBlockDependencyRef]        `json:"dependencyDefinitionUuids,omitempty" tfsdk:"dependency_refs"`
-	Implementation             MeshBuildingBlockDefinitionImplementation    `json:"implementation" tfsdk:"implementation"`
-	Inputs                     map[string]*MeshBuildingBlockDefinitionInput `json:"inputs" tfsdk:"inputs"`
+	// Replaces the deprecated bare-UUID dependencyDefinitionUuids; requires a backend serving it.
+	DependencyDefinitionRefs types.Set[UuidRef]                           `json:"dependencyDefinitionRefs,omitempty" tfsdk:"dependency_refs"`
+	Implementation           MeshBuildingBlockDefinitionImplementation    `json:"implementation" tfsdk:"implementation"`
+	Inputs                   map[string]*MeshBuildingBlockDefinitionInput `json:"inputs" tfsdk:"inputs"`
 }
 
 type MeshBuildingBlockDefinitionVersionStatus struct {

--- a/client/client.go
+++ b/client/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/meshcloud/terraform-provider-meshstack/client/version"
 )
 
-var MinMeshStackVersion = version.MustParse("2026.24.0")
+var MinMeshStackVersion = version.MustParse("2026.29.0")
 
 // HttpError represents an HTTP error response with status code.
 // This error is returned when an HTTP request fails with a non-2XX status code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: |-
 
 The meshStack terraform provider is an open-source tool, licensed under the MPL-2.0, and is actively maintained by meshcloud GmbH. The provider exposes APIs of meshStack to manage resources as code.
 
-**Note:** This provider version requires meshStack version 2026.24.0 or higher. The provider automatically validates version compatibility during initialization.
+**Note:** This provider version requires meshStack version 2026.29.0 or higher. The provider automatically validates version compatibility during initialization.
 
 ## Dependency wiring patterns
 

--- a/internal/provider/building_block_definition_resource_model.go
+++ b/internal/provider/building_block_definition_resource_model.go
@@ -122,19 +122,7 @@ func buildingBlockDefinitionVersionConverterOptions(ctx context.Context, config,
 			return generic.ValueFrom(in, secret.WithConverterSupport(ctx, config, plan, state).Append(generic.WithAttributePath(attributePath))...)
 		}),
 
-		// Handle DependencyDefinitionUUIDs
-		generic.WithValueToConverterFor[client.BuildingBlockDependencyRef](func(attributePath path.Path, in tftypes.Value) (client.BuildingBlockDependencyRef, error) {
-			ref, err := generic.ValueTo[buildingBlockDefinitionRef](in)
-			if err != nil {
-				return "", err
-			}
-			return client.BuildingBlockDependencyRef(ref.Uuid), nil
-		}),
-
-		generic.WithValueFromConverterFor[client.BuildingBlockDependencyRef](generic.ValueFromConverterForTypedNilHandler[buildingBlockDefinitionRef](),
-			func(attributePath path.Path, in client.BuildingBlockDependencyRef) (tftypes.Value, error) {
-				return generic.ValueFrom(newBuildingBlockDefinitionRef(string(in)))
-			}),
+		// dependency_refs (types.Set[client.UuidRef]) needs no custom converter — mapped generically like runner_ref.
 
 		// Handle version spec inputs: From Client DTO to model
 		generic.WithValueFromConverterFor[client.MeshBuildingBlockDefinitionInput](

--- a/internal/provider/building_block_definition_version_content_hash.go
+++ b/internal/provider/building_block_definition_version_content_hash.go
@@ -22,7 +22,8 @@ import (
 // instead of reporting a spurious "changed", which would rerun every already-released building block. Changing
 // the algorithm without bumping this is a silent breaking change.
 const (
-	currentHashVersion = 3
+	// v3: display_order folded into the hash. v4: dependencies hashed as dependencyDefinitionRefs.
+	currentHashVersion = 4
 )
 
 // represents a content hash of a building block definition version, which is used to detect changes in the version_spec.

--- a/internal/provider/building_block_definition_version_content_hash_test.go
+++ b/internal/provider/building_block_definition_version_content_hash_test.go
@@ -48,10 +48,10 @@ var (
 // So: change a digest below only alongside a deliberate hash-version bump, never on its own.
 func Test_versionContentHash(t *testing.T) {
 	const (
-		digestExample      = "7f843ccb4a53b679e245ac9281b3e2e957be674acc0f48ef1c7b8c2ba52f39a8"
-		digestRelevant     = "81e4e436f2e3730d0a5e0f2ec68570ec88cb7f82b93350d4e4d95de1208da57a"
+		digestExample      = "814c7b4eb579d555f4f1589bd34c4f913d250fe1d5fda7b2fdffe05e75fcd910"
+		digestRelevant     = "6ddbadbe5eb3baa76e7a2488f22ce62bd0e94eb380cbfbd55724231f704264dc"
 		digestNullOutputs  = "1a24f70de617e64fc258ceca4a4b7159ecebd9a95acd4ea40851e443c080038e"
-		digestDisplayOrder = "3a9fe010bfef3dfbc531742ab130bc2c559b86d9ba595d951dc5f2fb7bf6624c"
+		digestDisplayOrder = "a7cba4239e3d448387d188d1457bd3e00aa66694244dd6e26e8d7a055c9c4075"
 	)
 	require.NotEqual(t, digestExample, digestRelevant)
 
@@ -80,7 +80,7 @@ func Test_versionContentHash(t *testing.T) {
 // version instead of a spurious "changed" — see Test_contentHash_compareToStored_acrossVersions), so it must
 // be paired with an intentional edit here.
 func Test_contentHash_currentVersion(t *testing.T) {
-	require.Equal(t, 3, currentHashVersion)
+	require.Equal(t, 4, currentHashVersion)
 
 	h := forTestCalculateContentHash(t, versionSpecJson)
 	require.Equal(t, currentHashVersion, h.hashVersion)
@@ -133,9 +133,9 @@ func storedHash(version int, value string) string {
 }
 
 // Test_contentHash_compareToStored_acrossVersions is the heart of the version-bump contract: two hashes are
-// only comparable when their versions match. A stored hash from an older provider (v1 or v2) is therefore
-// incomparable to a current v3 hash — the case that must NOT be reported as "changed", because that would
-// rerun every already-released building block after a provider upgrade (issue behind the v2->v3 bump).
+// only comparable when their versions match. A stored hash from an older provider (v1, v2 or v3) is therefore
+// incomparable to a current v4 hash — the case that must NOT be reported as "changed", because that would
+// rerun every already-released building block after a provider upgrade (issue behind the v3->v4 bump).
 func Test_contentHash_compareToStored_acrossVersions(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -145,13 +145,14 @@ func Test_contentHash_compareToStored_acrossVersions(t *testing.T) {
 		storedValue  string
 		want         hashComparison
 	}{
-		{"same version, same value -> same", 3, "aaa", 3, "aaa", hashSame},
-		{"same version, different value -> different", 3, "aaa", 3, "bbb", hashDifferent},
+		{"same version, same value -> same", 4, "aaa", 4, "aaa", hashSame},
+		{"same version, different value -> different", 4, "aaa", 4, "bbb", hashDifferent},
 		{"legacy v1 self-consistent -> same", 1, "v1:h", 1, "v1:h", hashSame},
 		{"legacy v1 different value -> different", 1, "v1:h", 1, "v1:other", hashDifferent},
 		{"stored v1, current v2 -> incomparable", 2, "aaa", 1, "v1:h", hashIncomparable},
-		{"stored v1, current v3 -> incomparable", 3, "aaa", 1, "v1:h", hashIncomparable},
-		{"stored v2, current v3 -> incomparable", 3, "aaa", 2, "aaa", hashIncomparable},
+		{"stored v1, current v4 -> incomparable", 4, "aaa", 1, "v1:h", hashIncomparable},
+		{"stored v2, current v4 -> incomparable", 4, "aaa", 2, "aaa", hashIncomparable},
+		{"stored v3, current v4 -> incomparable", 4, "aaa", 3, "aaa", hashIncomparable},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/provider/testdata/bbd/version-spec-irrelevant-change.json
+++ b/internal/provider/testdata/bbd/version-spec-irrelevant-change.json
@@ -10,7 +10,13 @@
     "uuid" : "",
     "kind" : "meshBuildingBlockRunner"
   },
-  "dependencyDefinitionUuids" : [ "dep-2", "dep-1" ],
+  "dependencyDefinitionRefs" : [ {
+    "uuid" : "dep-2",
+    "kind" : "meshBuildingBlockDefinition"
+  }, {
+    "uuid" : "dep-1",
+    "kind" : "meshBuildingBlockDefinition"
+  } ],
   "outputs" : {
     "sign_in_url" : {
       "displayName" : "Sign-in URL",

--- a/internal/provider/testdata/bbd/version-spec-relevant-change.json
+++ b/internal/provider/testdata/bbd/version-spec-relevant-change.json
@@ -10,7 +10,13 @@
     "uuid" : "",
     "kind" : "meshBuildingBlockRunner"
   },
-  "dependencyDefinitionUuids" : [ "dep-2", "dep-1" ],
+  "dependencyDefinitionRefs" : [ {
+    "uuid" : "dep-2",
+    "kind" : "meshBuildingBlockDefinition"
+  }, {
+    "uuid" : "dep-1",
+    "kind" : "meshBuildingBlockDefinition"
+  } ],
   "outputs" : {
     "sign_in_url" : {
       "displayName" : "Sign-in URL",

--- a/internal/provider/testdata/bbd/version-spec-with-displayOrder.json
+++ b/internal/provider/testdata/bbd/version-spec-with-displayOrder.json
@@ -9,7 +9,13 @@
     "uuid" : "",
     "kind" : "meshBuildingBlockRunner"
   },
-  "dependencyDefinitionUuids" : [ "dep-1", "dep-2" ],
+  "dependencyDefinitionRefs" : [ {
+    "uuid" : "dep-1",
+    "kind" : "meshBuildingBlockDefinition"
+  }, {
+    "uuid" : "dep-2",
+    "kind" : "meshBuildingBlockDefinition"
+  } ],
   "outputs" : {
     "sign_in_url" : {
       "displayName" : "Sign-in URL",

--- a/internal/provider/testdata/bbd/version-spec-with-plaintext-secret.json
+++ b/internal/provider/testdata/bbd/version-spec-with-plaintext-secret.json
@@ -10,7 +10,13 @@
     "uuid" : "",
     "kind" : "meshBuildingBlockRunner"
   },
-  "dependencyDefinitionUuids" : [ "dep-2", "dep-1" ],
+  "dependencyDefinitionRefs" : [ {
+    "uuid" : "dep-2",
+    "kind" : "meshBuildingBlockDefinition"
+  }, {
+    "uuid" : "dep-1",
+    "kind" : "meshBuildingBlockDefinition"
+  } ],
   "outputs" : {
     "sign_in_url" : {
       "displayName" : "Sign-in URL",

--- a/internal/provider/testdata/bbd/version-spec-with-reordered-inputs.json
+++ b/internal/provider/testdata/bbd/version-spec-with-reordered-inputs.json
@@ -9,7 +9,13 @@
     "uuid" : "",
     "kind" : "meshBuildingBlockRunner"
   },
-  "dependencyDefinitionUuids" : [ "dep-1", "dep-2" ],
+  "dependencyDefinitionRefs" : [ {
+    "uuid" : "dep-1",
+    "kind" : "meshBuildingBlockDefinition"
+  }, {
+    "uuid" : "dep-2",
+    "kind" : "meshBuildingBlockDefinition"
+  } ],
   "outputs" : {
     "sign_in_url" : {
       "displayName" : "Sign-in URL",

--- a/internal/provider/testdata/bbd/version-spec.json
+++ b/internal/provider/testdata/bbd/version-spec.json
@@ -9,7 +9,13 @@
     "uuid" : "",
     "kind" : "meshBuildingBlockRunner"
   },
-  "dependencyDefinitionUuids" : [ "dep-1", "dep-2" ],
+  "dependencyDefinitionRefs" : [ {
+    "uuid" : "dep-1",
+    "kind" : "meshBuildingBlockDefinition"
+  }, {
+    "uuid" : "dep-2",
+    "kind" : "meshBuildingBlockDefinition"
+  } ],
   "outputs" : {
     "sign_in_url" : {
       "displayName" : "Sign-in URL",


### PR DESCRIPTION
## What

Switches the `meshBuildingBlockDefinitionVersion` dependency wire field from the deprecated `dependencyDefinitionUuids` (bare UUID array) to `dependencyDefinitionRefs` (`{uuid, kind}`), **while staying on the current `v1-preview` media type**. The Terraform **resource schema is unchanged** — `version_spec.dependency_refs` still takes `{kind, uuid}` refs, no config or state migration — only the serialized payload changes, so a dependency's `kind` now round-trips. Client field is now `types.Set[client.UuidRef]` (no custom converter; mapped generically like `runner_ref`). Content-hash bumped **v3 → v4** (old hashes gracefully recompute, no spurious re-run).

## Why — cross-repo compatibility handshake

This is the coordinated provider adaptation required by the `terraform-provider-compat` handshake for the backend GA work that **removes the deprecated `dependencyDefinitionUuids` field**. Released providers read *and* write `dependencyDefinitionUuids` and would **silently stop round-tripping dependencies** once the backend drops it.

By migrating the field onto the existing preview media type, this provider can be **released and adopted before** the backend removal deploys — independent of the separate GA media-type flip. It relies only on the additive `dependencyDefinitionRefs` field already served in preview (backend PR #10411, releasing in meshStack **2026.29.0**), not on the GA `v1` media type.

## Deployment ordering

1. Release + adopt this provider (preview + refs).
2. Then the backend field-removal + GA flip can deploy safely.
3. GA media-type flip provider PR (#243) follows separately.

## Compatibility

`MinMeshStackVersion` bumped `2026.24.0 → 2026.29.0` (the release whose preview BBD-version API serves `dependencyDefinitionRefs`).

## Testing

- `go build ./...`, `task test` (unit), `task lint` (0 issues), `task generate` — all green.
- Content-hash digests recomputed for v4 across the 6 `testdata/bbd` fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)