### PR TITLE
test: cover permission-scoped unfiltered meshBuildingBlock v2 list

### DIFF
--- a/client/tenant_v4.go
+++ b/client/tenant_v4.go
@@ -155,7 +155,11 @@ type MeshTenantSpec struct {
 
 // MeshTenantStatus has no quotas field; quotas are part of the tenant spec, not its status.
 type MeshTenantStatus struct {
-	TenantIdentifier       string              `json:"tenantIdentifier" tfsdk:"tenant_identifier"`
+	// Sourced from the backend's status.tenantName (the qualified tenant identifier). The v4 GA
+	// API renamed tenantIdentifier -> tenantName and drops the deprecated tenantIdentifier; the
+	// public tenant_identifier attribute keeps its name since the value (qualifiedTenantIdentifier)
+	// is unchanged.
+	TenantIdentifier       string              `json:"tenantName" tfsdk:"tenant_identifier"`
 	PlatformTypeIdentifier string              `json:"platformTypeIdentifier" tfsdk:"platform_type_identifier"`
 	PlatformWorkspaceId    *string             `json:"platformWorkspaceId" tfsdk:"platform_workspace_id"`
 	Tags                   map[string][]string `json:"tags" tfsdk:"tags"`

--- a/examples/data-sources/meshstack_building_blocks/test-support_other_provider.tf
+++ b/examples/data-sources/meshstack_building_blocks/test-support_other_provider.tf
@@ -1,0 +1,15 @@
+variable "apikey_client_id" {
+  type     = string
+  nullable = false
+}
+
+variable "apikey_client_secret" {
+  type      = string
+  nullable  = false
+  sensitive = true
+}
+
+provider "meshstack-other" {
+  apikey    = var.apikey_client_id
+  apisecret = var.apikey_client_secret
+}

--- a/internal/provider/building_blocks_data_source_test.go
+++ b/internal/provider/building_blocks_data_source_test.go
@@ -1,8 +1,10 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
+	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -86,5 +88,123 @@ func TestAccBuildingBlocksDataSource(t *testing.T) {
 				},
 			},
 		})
+	})
+
+	// 03_permission_scoped_list exercises the meshfed change that scopes the *unfiltered* meshBuildingBlock
+	// v2 list by the caller's authority (one-permission-one-scope): MANAGED_BUILDINGBLOCK_LIST alone returns
+	// the blocks the caller manages (created from a definition its workspace owns) even across the workspace
+	// boundary, while BUILDINGBLOCK_LIST alone returns only the caller's own/consumed blocks. Workspace A
+	// owns the definition (manages); the block lives in the "other" workspace B (owned/consumed there); both
+	// API keys belong to A. So A's managed scope contains the block and A's own scope does not — an older
+	// backend, where an unfiltered managed-capable list only ever returned own/consumed blocks, would return
+	// nothing for the managed key. Acceptance-only: the mock client enforces no authority boundaries.
+	t.Run("03_permission_scoped_list", func(t *testing.T) {
+		if IsMockClientTest() {
+			t.Skip("permission-scoped listing requires real authority boundaries")
+		}
+
+		// Workspace A owns the BBD and therefore manages every block created from it.
+		workspaceConfig, workspaceAddr := testconfig.Workspace(t)
+		var bbdAddr testconfig.Traversal
+		bbdConfig := testconfig.Resource{Name: "building_block", Suffix: "_01_workspace"}.TestSupportConfig(t, "").WithFirstBlock(
+			testconfig.ExtractAddress(&bbdAddr),
+			testconfig.OwnedByWorkspace(workspaceAddr),
+		)
+
+		// Workspace B consumes: the block lives here, across the boundary from the definition owner.
+		var otherWorkspaceAddr testconfig.Traversal
+		otherWorkspaceConfig, _ := testconfig.Workspace(t)
+		otherWorkspaceConfig = otherWorkspaceConfig.WithFirstBlock(
+			testconfig.RenameKey("other"),
+			testconfig.ExtractAddress(&otherWorkspaceAddr),
+		)
+
+		// Two keys owned by A, each carrying exactly one list authority so the unfiltered list resolves to a
+		// single scope.
+		managedKeyConfig, managedKeyAddr := testconfig.ApiKey(t, workspaceAddr)
+		managedKeyConfig = managedKeyConfig.WithFirstBlock(
+			testconfig.RenameKey("managed"),
+			testconfig.ExtractAddress(&managedKeyAddr),
+			testconfig.Descend("spec", "permissions")(testconfig.SetRawExpr(`["MANAGED_BUILDINGBLOCK_LIST"]`)),
+		)
+		ownKeyConfig, ownKeyAddr := testconfig.ApiKey(t, workspaceAddr)
+		ownKeyConfig = ownKeyConfig.WithFirstBlock(
+			testconfig.RenameKey("own"),
+			testconfig.ExtractAddress(&ownKeyAddr),
+			testconfig.Descend("spec", "permissions")(testconfig.SetRawExpr(`["BUILDINGBLOCK_LIST"]`)),
+		)
+
+		// Admin-managed block in workspace B from A's definition (created/destroyed by the default provider's
+		// ADM_BUILDINGBLOCK_SAVE; the minted keys are only ever used to read the list).
+		var bbAddr testconfig.Traversal
+		bbConfig := testconfig.Resource{Name: "building_block", Suffix: "_01_workspace"}.Config(t).WithFirstBlock(
+			testconfig.ExtractAddress(&bbAddr),
+			testconfig.Descend("spec", "building_block_definition_version_ref")(testconfig.SetRawExpr(`{ uuid = %s }`, bbdAddr.Join("version_latest", "uuid"))),
+			testconfig.Descend("spec", "target_ref")(testconfig.SetAddr(otherWorkspaceAddr, "ref")),
+		)
+
+		support := workspaceConfig.Join(bbdConfig, otherWorkspaceConfig, managedKeyConfig, ownKeyConfig, bbConfig)
+		otherProvider := testconfig.DataSource{Name: "building_blocks"}.TestSupportConfig(t, "_other_provider")
+
+		// Fully unfiltered list read through the meshstack-other alias; the key credentials vary per step so
+		// the same data source resolves under each authority in turn.
+		listConfig := testconfig.DataSource{Name: "building_blocks"}.Config(t).WithFirstBlock(
+			testconfig.Descend("provider")(testconfig.SetRawExpr("meshstack-other")),
+		).Join(support, otherProvider)
+
+		dataSourceAddr := "data.meshstack_building_blocks.all"
+
+		var managedId, managedSecret, ownId, ownSecret lazyVariable
+		var bbUuid string
+		ApplyAndTest(t, resource.TestCase{Steps: []resource.TestStep{
+			{
+				// Admin: build the cross-workspace fixture and mint both keys.
+				Config: support.String(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(bbAddr.String(), tfjsonpath.New("metadata").AtMapKey("uuid"), xknownvalue.NotEmptyString(func(uuid string) error {
+						bbUuid = uuid
+						return nil
+					})),
+					statecheck.ExpectKnownValue(managedKeyAddr.String(), tfjsonpath.New("status").AtMapKey("client_id"), xknownvalue.NotEmptyString(func(v string) error {
+						managedId = lazyVariable(v)
+						return nil
+					})),
+					statecheck.ExpectKnownValue(managedKeyAddr.String(), tfjsonpath.New("status").AtMapKey("client_secret"), xknownvalue.NotEmptyString(func(v string) error {
+						managedSecret = lazyVariable(v)
+						return nil
+					})),
+					statecheck.ExpectKnownValue(ownKeyAddr.String(), tfjsonpath.New("status").AtMapKey("client_id"), xknownvalue.NotEmptyString(func(v string) error {
+						ownId = lazyVariable(v)
+						return nil
+					})),
+					statecheck.ExpectKnownValue(ownKeyAddr.String(), tfjsonpath.New("status").AtMapKey("client_secret"), xknownvalue.NotEmptyString(func(v string) error {
+						ownSecret = lazyVariable(v)
+						return nil
+					})),
+				},
+			},
+			{
+				// MANAGED_BUILDINGBLOCK_LIST alone → the cross-workspace managed block is the one and only result.
+				Config:          listConfig.String(),
+				ConfigVariables: tfconfig.Variables{"apikey_client_id": &managedId, "apikey_client_secret": &managedSecret},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceAddr, tfjsonpath.New("building_blocks"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(dataSourceAddr, tfjsonpath.New("building_blocks").AtSliceIndex(0).AtMapKey("metadata").AtMapKey("uuid"), xknownvalue.NotEmptyString(func(uuid string) error {
+						if uuid != bbUuid {
+							return fmt.Errorf("managed list returned block %q, expected the cross-workspace managed block %q", uuid, bbUuid)
+						}
+						return nil
+					})),
+				},
+			},
+			{
+				// BUILDINGBLOCK_LIST alone → own/consumed scope; workspace A owns no blocks → empty.
+				Config:          listConfig.String(),
+				ConfigVariables: tfconfig.Variables{"apikey_client_id": &ownId, "apikey_client_secret": &ownSecret},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceAddr, tfjsonpath.New("building_blocks"), knownvalue.ListSizeExact(0)),
+				},
+			},
+		}})
 	})
 }


### PR DESCRIPTION
## What

Adds an acceptance-only subtest `03_permission_scoped_list` to `TestAccBuildingBlocksDataSource`, covering the meshfed change that **scopes the unfiltered `meshBuildingBlock` v2 list by permission** (one-permission-one-scope):

- `MANAGED_BUILDINGBLOCK_LIST` alone → the blocks the caller *manages* (created from a definition its workspace owns), even across the workspace boundary.
- `BUILDINGBLOCK_LIST` alone → only the caller's *own/consumed* blocks.

The fixture puts the definition (and both API keys) in workspace A and the building block in the "other" workspace B, so A's managed scope contains the block while A's own scope does not — the case an older backend (unfiltered managed-capable list only ever returning own/consumed) would get wrong. Reads run through a `meshstack-other` provider alias whose credentials are the minted keys; a new `test-support_other_provider.tf` mirrors the one already used by the `meshstack_building_block_definitions` cross-workspace test.

Gated by `!IsMockClientTest` — the mock client enforces no authority boundaries.

## Cross-repo handshake

Pairs by branch name with **meshcloud/meshfed-release#10309** (which introduces the permission scoping). The authoritative run is that PR's `terraform-provider-acceptance` job, which builds the backend from its own source and pairs this same-named provider branch.

> This repo's own `terraform-provider-acceptance` CI runs against the **last-merged** meshfed backend, which does not yet have the scoping change — so `03_permission_scoped_list` will red here until meshfed #10309 merges. That is the documented companion-PR handshake, not a defect.

Test-only; no user-facing change, no CHANGELOG entry.
