### PR TITLE
fix: upgrade meshstack_landingzone state written before the computed …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ FIXES:
 
 - `meshstack_building_block_definition`: fixed plan drift on `version_spec.inputs.<key>.display_order` when importing existing resources or upgrading from a provider version where `display_order` was absent or state held server-assigned non-zero positions. When `display_order` was introduced in commit `46c496c6`, a schema default of `0` was added. Because HCL configurations omit `display_order`, Terraform evaluated the missing attribute as `0`, planning unwanted normalization changes (`1 → 0`, `2 → 0`) against state populated by the meshStack API. The attribute now uses the `UseNonNullStateForUnknown()` plan modifier instead of a static default, preserving server-assigned values from state while leaving a newly declared input's `display_order` known-after-apply.
 
+- `meshstack_landingzone`: upgrading from v0.23.3 or earlier now works. The schema version 0 → 1 tag migration added in v0.24.1 read prior state through the current schema, which includes the computed `ref` that only exists since v0.24.0. State written by an older provider has no `ref`, so every plan failed with *"Value Conversion Error … Received null value, however the target type cannot handle null values. Path: ref"*. The upgrader no longer expects `ref` in prior state and derives it from `metadata.name` instead. Upgrading from v0.24.0 is unaffected and stays supported.
 
 # v0.24.2
 

--- a/internal/provider/landingZone_upgrade.go
+++ b/internal/provider/landingZone_upgrade.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"context"
+	"maps"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/meshcloud/terraform-provider-meshstack/client"
+)
+
+// required for backwards compatibility of older versions of LZ in meshObject API.
+type landingZoneModelV0 struct {
+	Metadata client.MeshLandingZoneMetadata `tfsdk:"metadata"`
+	Spec     client.MeshLandingZoneSpec     `tfsdk:"spec"`
+	Status   client.MeshLandingZoneStatus   `tfsdk:"status"`
+}
+
+// landingZoneSchemaV0Once builds the legacy schema for the state upgrader:
+// the current schema with metadata.tags as its old set(string) type.
+// v1 corrected tags to list(string) so this exists only to read legacy state.
+var landingZoneSchemaV0Once = sync.OnceValue(func() schema.Schema {
+	var schemaResp resource.SchemaResponse
+	(&landingZoneResource{}).Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	s := schemaResp.Schema
+	s.Version = 0 // indicator for legacy version
+
+	metadata, ok := s.Attributes["metadata"].(schema.SingleNestedAttribute)
+	if !ok {
+		panic("landing zone metadata attribute is not a SingleNestedAttribute")
+	}
+	metadata.Attributes = maps.Clone(metadata.Attributes)
+	metadata.Attributes["tags"] = schema.MapAttribute{
+		ElementType: types.SetType{ElemType: types.StringType},
+		Optional:    true,
+		Computed:    true,
+		Default:     mapdefault.StaticValue(types.MapValueMust(types.SetType{ElemType: types.StringType}, map[string]attr.Value{})),
+	}
+	s.Attributes = maps.Clone(s.Attributes)
+	s.Attributes["metadata"] = metadata
+
+	// important to drop here to not have unexpected null values (the field did not exist at all in legacy LZ)
+	delete(s.Attributes, "ref")
+
+	return s
+})
+
+// upgradeTagsSetToList migrates legacy tags to proper LZ v1 state.
+func (r *landingZoneResource) upgradeTagsSetToList(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	var prior landingZoneModelV0
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, landingZoneModel{
+		Ref:      landingZoneRefOutput{Name: prior.Metadata.Name, Kind: client.MeshObjectKind.LandingZone},
+		Metadata: prior.Metadata,
+		Spec:     prior.Spec,
+		Status:   prior.Status,
+	})...)
+}

--- a/internal/provider/landingzone_resource.go
+++ b/internal/provider/landingzone_resource.go
@@ -58,6 +58,16 @@ type landingZoneModel struct {
 	Status   client.MeshLandingZoneStatus   `tfsdk:"status"`
 }
 
+// landingZoneModelV0 reads schema-version-0 state, which spans releases from before `ref` existed
+// (added in v0.24.0) up to v0.24.0 itself. Older state has no `ref` key at all, which unmarshals to
+// null and cannot be reflected into the non-nullable landingZoneRefOutput. The ref is name-derived,
+// so the upgrader drops it here and recomputes it.
+type landingZoneModelV0 struct {
+	Metadata client.MeshLandingZoneMetadata `tfsdk:"metadata"`
+	Spec     client.MeshLandingZoneSpec     `tfsdk:"spec"`
+	Status   client.MeshLandingZoneStatus   `tfsdk:"status"`
+}
+
 func landingZoneModelFrom(lz *client.MeshLandingZone) landingZoneModel {
 	return landingZoneModel{
 		Ref:      landingZoneRefOutput{Name: lz.Metadata.Name, Kind: client.MeshObjectKind.LandingZone},
@@ -615,6 +625,10 @@ var landingZoneSchemaV0Once = sync.OnceValue(func() schema.Schema {
 	}
 	s.Attributes = maps.Clone(s.Attributes)
 	s.Attributes["metadata"] = metadata
+	// Drop `ref`: it only entered the schema in v0.24.0, while version 0 also covers every release
+	// before that. Keeping it here would make state written by <= v0.23.3 unreadable (null object into
+	// landingZoneRefOutput); state written by v0.24.0 simply has its `ref` key ignored on unmarshal.
+	delete(s.Attributes, "ref")
 	return s
 })
 
@@ -628,10 +642,16 @@ func (r *landingZoneResource) UpgradeState(_ context.Context) map[int64]resource
 // upgradeTagsSetToListV0 migrates v0 (tags as set) state to v1 (list). The Go model holds tags as
 // map[string][]string, so a read-then-write under the current schema does the conversion losslessly.
 func (r *landingZoneResource) upgradeTagsSetToListV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	var model landingZoneModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	var prior landingZoneModelV0
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, landingZoneModel{
+		Ref:      landingZoneRefOutput{Name: prior.Metadata.Name, Kind: client.MeshObjectKind.LandingZone},
+		Metadata: prior.Metadata,
+		Spec:     prior.Spec,
+		Status:   prior.Status,
+	})...)
 }

--- a/internal/provider/landingzone_resource.go
+++ b/internal/provider/landingzone_resource.go
@@ -3,17 +3,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"maps"
 	"regexp"
-	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -53,16 +49,6 @@ type landingZoneRefOutput struct {
 // The client struct has no `ref` field, so we wrap it here rather than mutating client types.
 type landingZoneModel struct {
 	Ref      landingZoneRefOutput           `tfsdk:"ref"`
-	Metadata client.MeshLandingZoneMetadata `tfsdk:"metadata"`
-	Spec     client.MeshLandingZoneSpec     `tfsdk:"spec"`
-	Status   client.MeshLandingZoneStatus   `tfsdk:"status"`
-}
-
-// landingZoneModelV0 reads schema-version-0 state, which spans releases from before `ref` existed
-// (added in v0.24.0) up to v0.24.0 itself. Older state has no `ref` key at all, which unmarshals to
-// null and cannot be reflected into the non-nullable landingZoneRefOutput. The ref is name-derived,
-// so the upgrader drops it here and recomputes it.
-type landingZoneModelV0 struct {
 	Metadata client.MeshLandingZoneMetadata `tfsdk:"metadata"`
 	Spec     client.MeshLandingZoneSpec     `tfsdk:"spec"`
 	Status   client.MeshLandingZoneStatus   `tfsdk:"status"`
@@ -603,55 +589,9 @@ func (r *landingZoneResource) ImportState(ctx context.Context, req resource.Impo
 	resource.ImportStatePassthroughID(ctx, path.Root("metadata").AtName("name"), req, resp)
 }
 
-// landingZoneSchemaV0Once builds the v0 schema for the state upgrader: the current schema with
-// metadata.tags as its old set(string) type. v1 corrected tags to list(string) (tag values are
-// lists, not sets), so this exists only to read v0 state.
-var landingZoneSchemaV0Once = sync.OnceValue(func() schema.Schema {
-	var schemaResp resource.SchemaResponse
-	(&landingZoneResource{}).Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
-	s := schemaResp.Schema
-	s.Version = 0
-
-	metadata, ok := s.Attributes["metadata"].(schema.SingleNestedAttribute)
-	if !ok {
-		panic("landing zone metadata attribute is not a SingleNestedAttribute")
-	}
-	metadata.Attributes = maps.Clone(metadata.Attributes)
-	metadata.Attributes["tags"] = schema.MapAttribute{
-		ElementType: types.SetType{ElemType: types.StringType},
-		Optional:    true,
-		Computed:    true,
-		Default:     mapdefault.StaticValue(types.MapValueMust(types.SetType{ElemType: types.StringType}, map[string]attr.Value{})),
-	}
-	s.Attributes = maps.Clone(s.Attributes)
-	s.Attributes["metadata"] = metadata
-	// Drop `ref`: it only entered the schema in v0.24.0, while version 0 also covers every release
-	// before that. Keeping it here would make state written by <= v0.23.3 unreadable (null object into
-	// landingZoneRefOutput); state written by v0.24.0 simply has its `ref` key ignored on unmarshal.
-	delete(s.Attributes, "ref")
-	return s
-})
-
 func (r *landingZoneResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
 	prior := landingZoneSchemaV0Once()
 	return map[int64]resource.StateUpgrader{
-		0: {PriorSchema: &prior, StateUpgrader: r.upgradeTagsSetToListV0},
+		0: {PriorSchema: &prior, StateUpgrader: r.upgradeTagsSetToList},
 	}
-}
-
-// upgradeTagsSetToListV0 migrates v0 (tags as set) state to v1 (list). The Go model holds tags as
-// map[string][]string, so a read-then-write under the current schema does the conversion losslessly.
-func (r *landingZoneResource) upgradeTagsSetToListV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	var prior landingZoneModelV0
-	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, landingZoneModel{
-		Ref:      landingZoneRefOutput{Name: prior.Metadata.Name, Kind: client.MeshObjectKind.LandingZone},
-		Metadata: prior.Metadata,
-		Spec:     prior.Spec,
-		Status:   prior.Status,
-	})...)
 }

--- a/internal/provider/landingzone_state_upgrade_test.go
+++ b/internal/provider/landingzone_state_upgrade_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 )
 
-// v0.23.3 wrote landing zone state at schema version 0 without a `ref` key (added in v0.24.0) and
-// with tags as a set. Reading it back must not choke on the missing ref.
-const landingZoneStateV0WithoutRef = `{
+// v0.23.3 wrote landing zone state at schema version 0 without a `ref` key and with tags as a set.
+const landingZoneStateLegacy = `{
   "metadata": {
     "name": "example-default",
     "owned_by_workspace": "my-workspace",
@@ -33,7 +32,7 @@ const landingZoneStateV0WithoutRef = `{
   "status": {"disabled": false, "restricted": false}
 }`
 
-func TestLandingZoneUpgradeStateV0(t *testing.T) {
+func TestLandingZoneUpgradeState(t *testing.T) {
 	// The prior schema must not carry `ref`, but the live schema still must.
 	if _, ok := landingZoneSchemaV0Once().Attributes["ref"]; ok {
 		t.Error("prior v0 schema declares ref; state written before v0.24.0 has no such key")
@@ -43,7 +42,7 @@ func TestLandingZoneUpgradeStateV0(t *testing.T) {
 	}
 
 	var upgraded landingZoneModel
-	diags := UpgradeResourceStateFromJSON(t, &landingZoneResource{}, 0, landingZoneStateV0WithoutRef, &upgraded)
+	diags := UpgradeResourceStateFromJSON(t, &landingZoneResource{}, 0, landingZoneStateLegacy, &upgraded)
 	if diags.HasError() {
 		t.Fatalf("upgrade produced errors: %s", diags)
 	}

--- a/internal/provider/landingzone_state_upgrade_test.go
+++ b/internal/provider/landingzone_state_upgrade_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"testing"
+)
+
+// v0.23.3 wrote landing zone state at schema version 0 without a `ref` key (added in v0.24.0) and
+// with tags as a set. Reading it back must not choke on the missing ref.
+const landingZoneStateV0WithoutRef = `{
+  "metadata": {
+    "name": "example-default",
+    "owned_by_workspace": "my-workspace",
+    "tags": {"env": ["prod"]}
+  },
+  "spec": {
+    "display_name": "Example Default",
+    "description": "Default landing zone for example projects.",
+    "automate_deletion_approval": true,
+    "automate_deletion_replication": true,
+    "info_link": null,
+    "platform_ref": {"uuid": "a2b7cf9c-8e2a-4b0d-9e6f-1c4b9de3a111", "kind": "meshPlatform"},
+    "platform_properties": {
+      "type": "custom",
+      "aws": null, "aks": null, "azure": null, "azurerg": null,
+      "custom": {}, "gcp": null, "kubernetes": null, "openshift": null
+    },
+    "quotas": [],
+    "mandatory_building_block_refs": [
+      {"uuid": "6d1f0b3e-5a44-4d1c-90a2-7b8e2f0c5d22", "kind": "meshBuildingBlockDefinition"}
+    ],
+    "recommended_building_block_refs": []
+  },
+  "status": {"disabled": false, "restricted": false}
+}`
+
+func TestLandingZoneUpgradeStateV0(t *testing.T) {
+	// The prior schema must not carry `ref`, but the live schema still must.
+	if _, ok := landingZoneSchemaV0Once().Attributes["ref"]; ok {
+		t.Error("prior v0 schema declares ref; state written before v0.24.0 has no such key")
+	}
+	if _, ok := ResourceSchemaForTest(t, &landingZoneResource{}).Attributes["ref"]; !ok {
+		t.Fatal("current schema lost its ref attribute")
+	}
+
+	var upgraded landingZoneModel
+	diags := UpgradeResourceStateFromJSON(t, &landingZoneResource{}, 0, landingZoneStateV0WithoutRef, &upgraded)
+	if diags.HasError() {
+		t.Fatalf("upgrade produced errors: %s", diags)
+	}
+
+	if upgraded.Ref.Name != "example-default" || upgraded.Ref.Kind != "meshLandingZone" {
+		t.Errorf("ref not recomputed from metadata.name, got %+v", upgraded.Ref)
+	}
+	if got := upgraded.Metadata.Tags["env"]; len(got) != 1 || got[0] != "prod" {
+		t.Errorf("tags not carried over as a list, got %v", upgraded.Metadata.Tags)
+	}
+	if upgraded.Spec.DisplayName != "Example Default" {
+		t.Errorf("spec not carried over, got %+v", upgraded.Spec)
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -10,7 +10,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	fwschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
 
@@ -157,6 +161,55 @@ func moduleRoot(t *testing.T) string {
 		require.NotEqualf(t, parent, dir, "could not locate go.mod above %s", dir)
 		dir = parent
 	}
+}
+
+// ResourceSchemaForTest returns a resource's current schema, so tests can assert on its attributes
+// without importing the framework themselves.
+func ResourceSchemaForTest(t *testing.T, r fwresource.Resource) fwschema.Schema {
+	t.Helper()
+
+	var resp fwresource.SchemaResponse
+	r.Schema(context.Background(), fwresource.SchemaRequest{}, &resp)
+	require.False(t, resp.Diagnostics.HasError(), "building schema: %s", resp.Diagnostics)
+
+	return resp.Schema
+}
+
+// UpgradeResourceStateFromJSON drives a resource's state upgrader over raw prior-state JSON the way
+// the framework does — JSON keys absent from the prior schema are skipped, and attributes the prior
+// schema declares but the JSON omits decode to null — then reads the upgraded state into target.
+// Returns the upgrade's diagnostics so a test can assert on a rejected upgrade too.
+//
+// Driving the upgrader directly is what makes a pre-release state shape testable at all: reproducing
+// it through Terraform would mean installing an older published provider and applying against a real
+// backend.
+func UpgradeResourceStateFromJSON(t *testing.T, r fwresource.ResourceWithUpgradeState, version int64, rawJSON string, target any) diag.Diagnostics {
+	t.Helper()
+
+	ctx := context.Background()
+
+	upgrader, ok := r.UpgradeState(ctx)[version]
+	require.Truef(t, ok, "resource declares no state upgrader for version %d", version)
+	require.NotNilf(t, upgrader.PriorSchema, "state upgrader for version %d has no PriorSchema", version)
+
+	priorValue, err := tfprotov6.RawState{JSON: []byte(rawJSON)}.UnmarshalWithOpts(
+		upgrader.PriorSchema.Type().TerraformType(ctx),
+		tfprotov6.UnmarshalOpts{ValueFromJSONOpts: tftypes.ValueFromJSONOpts{IgnoreUndefinedAttributes: true}},
+	)
+	require.NoError(t, err, "decoding prior state against the upgrader's PriorSchema")
+
+	req := fwresource.UpgradeStateRequest{State: &tfsdk.State{Raw: priorValue, Schema: *upgrader.PriorSchema}}
+	// Raw is left unset, as the framework does when it calls the upgrader.
+	resp := fwresource.UpgradeStateResponse{State: tfsdk.State{Schema: ResourceSchemaForTest(t, r)}}
+
+	upgrader.StateUpgrader(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		return resp.Diagnostics
+	}
+
+	resp.Diagnostics.Append(resp.State.Get(ctx, target)...)
+
+	return resp.Diagnostics
 }
 
 // sanitizeTestName turns a *testing.T name into a relative path. Subtest separators ("/")


### PR DESCRIPTION
…ref existed

The v0 to v1 tag migration read prior state through the current schema, so state from a provider without the computed `ref` failed every plan with a null-value conversion error. Derive the ref from metadata.name instead.