### PR TITLE
feat!: remove the deprecated spec.quotas from meshstack_tenant (CU-86c0j0r7q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.24.4
 
 BREAKING CHANGES:
+- `meshstack_tenant` (resource and data source) and `meshstack_tenants`: the deprecated `spec.quotas` set of `{key, value}` entries has been removed. Request quotas through the `spec.requested_quotas` map (`{ "limits.cpu" = { value = 4 } }`) and read the effective values from the computed `status.applied_quotas`; both shipped in v0.24.3. This only stops the provider from sending a field the meshTenant API deprecated, so it needs no newer meshStack version. Existing state is migrated automatically (`meshstack_tenant` schema version 1 -> 2): a quota recorded under `spec.quotas` is translated into `spec.requested_quotas`, so a configuration that restates the same quotas in the map form plans no change. Update any configuration still using `quotas = [...]`, which is no longer a valid argument. The deprecated `meshstack_tenant_v4` resource is unaffected and keeps its own `spec.quotas`.
 - `meshstack_building_block`: `spec.parent_building_blocks` is renamed to `spec.parent_building_block_refs`, and it now holds a plain set of building block references. Each element was a `{buildingblock_uuid, definition_uuid}` object and is now a `{kind, uuid}` ref (`kind` defaults to `meshBuildingBlock`). One ref replaces both fields, because meshStack derives a parent's definition from the referenced building block. The new name says what the attribute holds, and it changes in the same release as the element shape, so you edit each of these blocks only once. To migrate, rename the attribute, then replace each object with a ref:
 
   ```hcl

--- a/client/tenant_v4.go
+++ b/client/tenant_v4.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client/internal"
-	"github.com/meshcloud/terraform-provider-meshstack/client/types"
 	"github.com/meshcloud/terraform-provider-meshstack/client/types/enum"
 )
 
@@ -168,8 +167,6 @@ type MeshTenantSpec struct {
 	// {"limits.cpu": {"value": 4}}. The backend does not return it on read (it is a create-time input),
 	// so the resource echoes the configured value from state.
 	RequestedQuotas map[string]RequestQuotaValue `json:"requestedQuotas" tfsdk:"requested_quotas"`
-	// Deprecated: superseded by RequestedQuotas; retained so existing configurations keep working.
-	Quotas types.Set[MeshTenantQuota] `json:"quotas" tfsdk:"quotas"`
 }
 
 type MeshTenantStatus struct {
@@ -221,14 +218,10 @@ type MeshTenantCreateMetadata struct {
 }
 
 type MeshTenantCreateSpec struct {
-	PlatformRef      UuidRef   `json:"platformRef" tfsdk:"platform_ref"`
-	LandingZoneRef   *NamedRef `json:"landingZoneRef" tfsdk:"landing_zone_ref"`
-	PlatformTenantId *string   `json:"platformTenantId" tfsdk:"platform_tenant_id"`
-	// RequestedQuotas is the preferred key->value form. Only one of the two quota fields should be
-	// set — the backend rejects a create that carries both with conflicting values.
-	RequestedQuotas map[string]RequestQuotaValue `json:"requestedQuotas,omitempty" tfsdk:"requested_quotas"`
-	// Deprecated: superseded by RequestedQuotas; retained so existing configurations keep working.
-	Quotas types.Set[MeshTenantQuota] `json:"quotas,omitempty" tfsdk:"quotas"`
+	PlatformRef      UuidRef                      `json:"platformRef" tfsdk:"platform_ref"`
+	LandingZoneRef   *NamedRef                    `json:"landingZoneRef" tfsdk:"landing_zone_ref"`
+	PlatformTenantId *string                      `json:"platformTenantId" tfsdk:"platform_tenant_id"`
+	RequestedQuotas  map[string]RequestQuotaValue `json:"requestedQuotas,omitempty" tfsdk:"requested_quotas"`
 }
 
 type MeshTenantQuery struct {

--- a/docs/data-sources/tenant.md
+++ b/docs/data-sources/tenant.md
@@ -59,7 +59,6 @@ Read-Only:
 - `landing_zone_ref` (Attributes) Reference to the landing zone assigned to this tenant, identified by its name (the landing zone identifier). (see [below for nested schema](#nestedatt--spec--landing_zone_ref))
 - `platform_ref` (Attributes) Reference to the platform this tenant belongs to, identified by its uuid. (see [below for nested schema](#nestedatt--spec--platform_ref))
 - `platform_tenant_id` (String)
-- `quotas` (Attributes Set, Deprecated) Deprecated: use `requested_quotas` instead. The requested quotas as a list of `{key, value}` entries. (see [below for nested schema](#nestedatt--spec--quotas))
 - `requested_quotas` (Attributes Map) The quotas requested for this tenant at creation, as a map keyed by quota key whose value is an object carrying the requested `value`. This is a create-time input that the meshStack API does not return on read, so it is typically null here; read the effective quotas from `status.applied_quotas` instead. (see [below for nested schema](#nestedatt--spec--requested_quotas))
 
 <a id="nestedatt--spec--landing_zone_ref"></a>
@@ -78,15 +77,6 @@ Read-Only:
 
 - `kind` (String) meshObject type, always `meshPlatform`.
 - `uuid` (String) UUID (`metadata.uuid`) of `meshPlatform`.
-
-
-<a id="nestedatt--spec--quotas"></a>
-### Nested Schema for `spec.quotas`
-
-Read-Only:
-
-- `key` (String)
-- `value` (Number)
 
 
 <a id="nestedatt--spec--requested_quotas"></a>

--- a/docs/data-sources/tenants.md
+++ b/docs/data-sources/tenants.md
@@ -78,7 +78,6 @@ Read-Only:
 - `landing_zone_ref` (Attributes) Reference to the landing zone assigned to this tenant, identified by its name (the landing zone identifier). (see [below for nested schema](#nestedatt--tenants--spec--landing_zone_ref))
 - `platform_ref` (Attributes) Reference to the platform this tenant belongs to, identified by its uuid. (see [below for nested schema](#nestedatt--tenants--spec--platform_ref))
 - `platform_tenant_id` (String)
-- `quotas` (Attributes List, Deprecated) Deprecated: use `requested_quotas` instead. The requested quotas as a list of `{key, value}` entries. (see [below for nested schema](#nestedatt--tenants--spec--quotas))
 - `requested_quotas` (Attributes Map) The quotas requested for this tenant at creation, as a map keyed by quota key whose value is an object carrying the requested `value`. This is a create-time input that the meshStack API does not return on read, so it is typically null here; read the effective quotas from `status.applied_quotas` instead. (see [below for nested schema](#nestedatt--tenants--spec--requested_quotas))
 
 <a id="nestedatt--tenants--spec--landing_zone_ref"></a>
@@ -97,15 +96,6 @@ Read-Only:
 
 - `kind` (String) meshObject type, always `meshPlatform`.
 - `uuid` (String) UUID (`metadata.uuid`) of `meshPlatform`.
-
-
-<a id="nestedatt--tenants--spec--quotas"></a>
-### Nested Schema for `tenants.spec.quotas`
-
-Read-Only:
-
-- `key` (String)
-- `value` (Number)
 
 
 <a id="nestedatt--tenants--spec--requested_quotas"></a>

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -92,7 +92,6 @@ Optional:
 
 - `landing_zone_ref` (Attributes) Reference to the landing zone to assign to this tenant, identified by its name (the landing zone identifier). (see [below for nested schema](#nestedatt--spec--landing_zone_ref))
 - `platform_tenant_id` (String) The identifier of the tenant on the platform (e.g. GCP project ID or Azure subscription ID). If this is not set, a new tenant will be created. If this is set, an existing tenant will be imported. Otherwise, this field will be empty until a successful replication has run.
-- `quotas` (Attributes Set, Deprecated) Deprecated: use `requested_quotas` instead, which models quotas as a `key -> value` map. Providing both is rejected when they disagree. Quotas to apply to the tenant at creation as a list of `{key, value}` entries. (see [below for nested schema](#nestedatt--spec--quotas))
 - `requested_quotas` (Attributes Map) Quotas to apply to the tenant at creation, as a map keyed by quota key whose value is an object carrying the requested `value` (e.g. `{ "limits.cpu" = { value = 4 } }`). The value is wrapped in an object to match the meshStack API and to allow per-quota fields to be added later without a breaking change. Requested values are applied as configured, merged into the landing zone's default quotas, which apply for every key not requested here. A value outside the quota's `[min_value, max_value]` bounds is rejected, as is an increase beyond the platform's auto-approval threshold (measured against those landing-zone defaults) unless the API key has admin privileges: the meshObject API refuses such a request rather than queueing it for operator approval, so an apply never reports success on quotas that are not in effect. Set only at creation: the meshTenant API cannot update a tenant, so changing this on an existing tenant is rejected. To change a live tenant's quotas, file a quota request in the meshStack panel (Tenant > Settings > Quotas), which is subject to platform-operator approval. (see [below for nested schema](#nestedatt--spec--requested_quotas))
 
 <a id="nestedatt--spec--platform_ref"></a>
@@ -114,15 +113,6 @@ Optional:
 
 - `kind` (String) meshObject type, always `meshLandingZone`.
 - `name` (String) Named identifier (`metadata.name`) of `meshLandingZone`.
-
-
-<a id="nestedatt--spec--quotas"></a>
-### Nested Schema for `spec.quotas`
-
-Required:
-
-- `key` (String)
-- `value` (Number)
 
 
 <a id="nestedatt--spec--requested_quotas"></a>

--- a/internal/clientmock/mock_tenant.go
+++ b/internal/clientmock/mock_tenant.go
@@ -45,7 +45,7 @@ func (m MeshTenantClient) Create(_ context.Context, tenant *client.MeshTenantCre
 	// The mock applies the requested quotas verbatim (it enforces no bounds or auto-approval threshold),
 	// but does overlay them on the landing zone's default quotas as the backend does, so
 	// status.appliedQuotas can legitimately carry keys the caller never requested.
-	appliedQuotas := effectiveQuotas(m.landingZoneDefaultQuotas(tenant.Spec.LandingZoneRef), tenant.Spec.RequestedQuotas, tenant.Spec.Quotas) //nolint:staticcheck // the mock must keep serving the deprecated quotas form
+	appliedQuotas := effectiveQuotas(m.landingZoneDefaultQuotas(tenant.Spec.LandingZoneRef), tenant.Spec.RequestedQuotas, nil)
 
 	created := &client.MeshTenant{
 		Metadata: client.MeshTenantMetadata{
@@ -58,7 +58,6 @@ func (m MeshTenantClient) Create(_ context.Context, tenant *client.MeshTenantCre
 			PlatformTenantId: new(acctest.RandString(16)),
 			LandingZoneRef:   tenant.Spec.LandingZoneRef,
 			RequestedQuotas:  tenant.Spec.RequestedQuotas,
-			Quotas:           tenant.Spec.Quotas, //nolint:staticcheck // the mock must keep serving the deprecated quotas form
 		},
 		Status: client.MeshTenantStatus{
 			TenantName:             tenantName,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -176,6 +176,18 @@ func ResourceSchemaForTest(t *testing.T, r fwresource.Resource) fwschema.Schema 
 	return resp.Schema
 }
 
+// HasNestedAttributeForTest reports whether a schema's single-nested attribute declares the given
+// child, e.g. spec.quotas.
+func HasNestedAttributeForTest(t *testing.T, s fwschema.Schema, parent, child string) bool {
+	t.Helper()
+
+	nested, ok := s.Attributes[parent].(fwschema.SingleNestedAttribute)
+	require.Truef(t, ok, "%s attribute is %T, want SingleNestedAttribute", parent, s.Attributes[parent])
+
+	_, found := nested.Attributes[child]
+	return found
+}
+
 // UpgradeResourceStateFromJSON drives a resource's state upgrader over raw prior-state JSON the way
 // the framework does — JSON keys absent from the prior schema are skipped, and attributes the prior
 // schema declares but the JSON omits decode to null — then reads the upgraded state into target.

--- a/internal/provider/tenant_data_source.go
+++ b/internal/provider/tenant_data_source.go
@@ -74,17 +74,6 @@ func (d *tenantDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 							},
 						},
 					},
-					"quotas": schema.SetNestedAttribute{
-						MarkdownDescription: "Deprecated: use `requested_quotas` instead. The requested quotas as a list of `{key, value}` entries.",
-						DeprecationMessage:  "Use `requested_quotas` (a key -> value map) instead.",
-						Computed:            true,
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"key":   schema.StringAttribute{Computed: true},
-								"value": schema.Int64Attribute{Computed: true},
-							},
-						},
-					},
 				},
 			},
 

--- a/internal/provider/tenant_model.go
+++ b/internal/provider/tenant_model.go
@@ -38,13 +38,11 @@ type tenantResourceModel struct {
 	WaitForCompletion bool                      `tfsdk:"wait_for_completion"`
 }
 
-// tenantResourceModelFromDto builds the resource state from an API response. specQuotas and
-// specRequestedQuotas are the known (configured) spec quota fields carried from plan/state: both are
-// Optional (not computed), so they must echo the configured value verbatim to avoid an
-// inconsistent-result-after-apply error when the backend defaults or reorders quotas.
-func tenantResourceModelFromDto(dto *client.MeshTenant, specQuotas clientTypes.Set[client.MeshTenantQuota], specRequestedQuotas map[string]client.RequestQuotaValue, waitForCompletion bool) tenantResourceModel {
+// tenantResourceModelFromDto takes specRequestedQuotas separately because spec.requested_quotas is
+// Optional (not computed) and create-only: the backend never returns it, so state must echo the value
+// the caller configured or the apply fails with an inconsistent result.
+func tenantResourceModelFromDto(dto *client.MeshTenant, specRequestedQuotas map[string]client.RequestQuotaValue, waitForCompletion bool) tenantResourceModel {
 	spec := dto.Spec
-	spec.Quotas = specQuotas //nolint:staticcheck // bridging the deprecated quotas field for backward compatibility
 	spec.RequestedQuotas = specRequestedQuotas
 	return tenantResourceModel{
 		Ref:               tenantRef{Kind: client.MeshObjectKind.Tenant, Uuid: dto.Metadata.Uuid},

--- a/internal/provider/tenant_quotas.go
+++ b/internal/provider/tenant_quotas.go
@@ -8,27 +8,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
+	clientTypes "github.com/meshcloud/terraform-provider-meshstack/client/types"
 )
 
-// requestedQuotaValues flattens the quotas a caller requested — from the preferred requested_quotas
-// map or, failing that, the deprecated quotas list — into a plain key->value map. Returns nil when no
-// quotas were requested.
+// requestedQuotaValues flattens spec.requested_quotas into a plain key->value map. Returns nil when empty.
 func requestedQuotaValues(spec client.MeshTenantSpec) map[string]int64 {
-	if len(spec.RequestedQuotas) > 0 {
-		out := make(map[string]int64, len(spec.RequestedQuotas))
-		for k, v := range spec.RequestedQuotas {
-			out[k] = v.Value
-		}
-		return out
+	if len(spec.RequestedQuotas) == 0 {
+		return nil
 	}
-	if deprecated := spec.Quotas; len(deprecated) > 0 { //nolint:staticcheck // bridging the deprecated quotas field for backward compatibility
-		out := make(map[string]int64, len(deprecated))
-		for _, q := range deprecated {
-			out[q.Key] = q.Value
-		}
-		return out
+	out := make(map[string]int64, len(spec.RequestedQuotas))
+	for k, v := range spec.RequestedQuotas {
+		out[k] = v.Value
 	}
-	return nil
+	return out
 }
 
 // appliedQuotaValues flattens status.applied_quotas into a plain key->value map. Returns nil when empty.
@@ -93,4 +85,20 @@ func warnOnUnrealizedQuotas(spec client.MeshTenantSpec, status client.MeshTenant
 	if summary, detail, ok := quotaRealizationWarning(requestedQuotaValues(spec), appliedQuotaValues(status)); ok {
 		diags.AddWarning(summary, detail)
 	}
+}
+
+// quotaListToRequestedMap translates the removed list-form spec.quotas into the spec.requested_quotas
+// map, so a configuration that restates the same quotas as a map plans no change — and it must not plan
+// one, because the meshTenant API cannot update the quotas of an existing tenant. Returns nil for an
+// empty list: an empty map would itself plan as a change against a configuration that omits the
+// Optional attribute.
+func quotaListToRequestedMap(quotas clientTypes.Set[client.MeshTenantQuota]) map[string]client.RequestQuotaValue {
+	if len(quotas) == 0 {
+		return nil
+	}
+	out := make(map[string]client.RequestQuotaValue, len(quotas))
+	for _, q := range quotas {
+		out[q.Key] = client.RequestQuotaValue{Value: q.Value}
+	}
+	return out
 }

--- a/internal/provider/tenant_quotas_test.go
+++ b/internal/provider/tenant_quotas_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -67,10 +68,9 @@ func TestQuotaRealizationWarning(t *testing.T) {
 }
 
 func TestRequestedQuotaValues(t *testing.T) {
-	t.Run("prefers requested_quotas map", func(t *testing.T) {
+	t.Run("flattens the requested_quotas map", func(t *testing.T) {
 		spec := client.MeshTenantSpec{
 			RequestedQuotas: map[string]client.RequestQuotaValue{"limits.cpu": {Value: 4}},
-			Quotas:          clientTypes.Set[client.MeshTenantQuota]{{Key: "limits.cpu", Value: 99}},
 		}
 		got := requestedQuotaValues(spec)
 		if len(got) != 1 || got["limits.cpu"] != 4 {
@@ -78,18 +78,31 @@ func TestRequestedQuotaValues(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to deprecated quotas list", func(t *testing.T) {
-		spec := client.MeshTenantSpec{
-			Quotas: clientTypes.Set[client.MeshTenantQuota]{{Key: "limits.cpu", Value: 7}},
+	t.Run("nil when nothing requested", func(t *testing.T) {
+		if got := requestedQuotaValues(client.MeshTenantSpec{}); got != nil {
+			t.Fatalf("got %v, want nil", got)
 		}
-		got := requestedQuotaValues(spec)
-		if len(got) != 1 || got["limits.cpu"] != 7 {
-			t.Fatalf("got %v, want map[limits.cpu:7]", got)
+	})
+}
+
+func TestQuotaListToRequestedMap(t *testing.T) {
+	t.Run("translates the list into the requested_quotas map", func(t *testing.T) {
+		got := quotaListToRequestedMap(clientTypes.Set[client.MeshTenantQuota]{
+			{Key: "limits.cpu", Value: 4},
+			{Key: "limits.memory", Value: 8},
+		})
+
+		want := map[string]client.RequestQuotaValue{
+			"limits.cpu":    {Value: 4},
+			"limits.memory": {Value: 8},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
 		}
 	})
 
-	t.Run("nil when nothing requested", func(t *testing.T) {
-		if got := requestedQuotaValues(client.MeshTenantSpec{}); got != nil {
+	t.Run("nil for an empty list", func(t *testing.T) {
+		if got := quotaListToRequestedMap(nil); got != nil {
 			t.Fatalf("got %v, want nil", got)
 		}
 	})

--- a/internal/provider/tenant_resource.go
+++ b/internal/provider/tenant_resource.go
@@ -54,7 +54,7 @@ func (r *tenantResource) Configure(_ context.Context, req resource.ConfigureRequ
 
 func (r *tenantResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version:             1,
+		Version:             2,
 		MarkdownDescription: "Manages a `meshTenant`." + previewDisclaimer(),
 		Attributes:          tenantBodyAttributes(),
 	}
@@ -76,7 +76,6 @@ func (r *tenantResource) Create(ctx context.Context, req resource.CreateRequest,
 			PlatformTenantId: plan.Spec.PlatformTenantId,
 			LandingZoneRef:   plan.Spec.LandingZoneRef,
 			RequestedQuotas:  plan.Spec.RequestedQuotas,
-			Quotas:           plan.Spec.Quotas, //nolint:staticcheck // bridging the deprecated quotas field for backward compatibility
 		},
 	}
 
@@ -97,7 +96,7 @@ func (r *tenantResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	warnOnUnrealizedQuotas(plan.Spec, tenant.Status, &resp.Diagnostics)
 
-	model := tenantResourceModelFromDto(tenant, plan.Spec.Quotas, plan.Spec.RequestedQuotas, plan.WaitForCompletion) //nolint:staticcheck // bridging the deprecated quotas field for backward compatibility
+	model := tenantResourceModelFromDto(tenant, plan.Spec.RequestedQuotas, plan.WaitForCompletion)
 	resp.Diagnostics.Append(generic.Set(ctx, &resp.State, model, tenantConverterOptions()...)...)
 }
 
@@ -122,9 +121,7 @@ func (r *tenantResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// was requested — the tenant's quotas were changed outside Terraform, e.g. by a platform operator.
 	warnOnUnrealizedQuotas(state.Spec, tenant.Status, &resp.Diagnostics)
 
-	// spec.requested_quotas / spec.quotas are Optional (not computed), so preserve the configured value
-	// from state rather than the backend's (possibly landing-zone-defaulted) spec quotas.
-	model := tenantResourceModelFromDto(tenant, state.Spec.Quotas, state.Spec.RequestedQuotas, state.WaitForCompletion) //nolint:staticcheck // bridging the deprecated quotas field for backward compatibility
+	model := tenantResourceModelFromDto(tenant, state.Spec.RequestedQuotas, state.WaitForCompletion)
 	resp.Diagnostics.Append(generic.Set(ctx, &resp.State, model, tenantConverterOptions()...)...)
 }
 
@@ -258,17 +255,12 @@ func (r *tenantResource) moveFromV4(ctx context.Context, req resource.MoveStateR
 		return
 	}
 
-	// spec.quotas is optional (not computed); carry the source's value so a configured value survives
-	// the move without churn.
+	// The source's spec.quotas is optional (not computed), so it holds what the caller configured.
 	var quotas clientTypes.Set[client.MeshTenantQuota]
 	if !src.Spec.Quotas.IsNull() && !src.Spec.Quotas.IsUnknown() {
 		resp.Diagnostics.Append(src.Spec.Quotas.ElementsAs(ctx, &quotas, false)...)
 	}
 
-	// Carry only the tenant uuid, its owning workspace/project, the configured spec.quotas and the
-	// client-side wait_for_completion toggle; the ref/platform_ref/landing_zone_ref/status outputs are
-	// left at their zero value and get overwritten by the refresh Read that follows the move (it
-	// re-reads the tenant by uuid).
 	target := tenantResourceModelFromDto(
 		&client.MeshTenant{
 			Metadata: client.MeshTenantMetadata{
@@ -278,19 +270,23 @@ func (r *tenantResource) moveFromV4(ctx context.Context, req resource.MoveStateR
 			},
 			Spec: client.MeshTenantSpec{PlatformTenantId: src.Spec.PlatformTenantId.ValueStringPointer()},
 		},
-		quotas,
-		nil,
+		quotaListToRequestedMap(quotas),
 		true,
 	)
 	resp.Diagnostics.Append(generic.Set(ctx, &resp.TargetState, target, tenantConverterOptions()...)...)
 }
 
 func (r *tenantResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
-	priorSchema := tenantV0Schema()
+	priorV0Schema := tenantV0Schema()
+	priorV1Schema := tenantSchemaV1Once()
 	return map[int64]resource.StateUpgrader{
 		0: {
-			PriorSchema:   &priorSchema,
+			PriorSchema:   &priorV0Schema,
 			StateUpgrader: r.upgradeFromV0,
+		},
+		1: {
+			PriorSchema:   &priorV1Schema,
+			StateUpgrader: r.upgradeFromV1,
 		},
 	}
 }
@@ -316,10 +312,9 @@ func (r *tenantResource) upgradeFromV0(ctx context.Context, req resource.Upgrade
 		return
 	}
 
-	// spec quotas are Optional (not computed) and echo the configured value; a migrated config that
-	// omits quotas plans null, so carry null here (not the backend's effective quotas, often an empty
-	// set) to avoid a spurious spec quota diff that would route to the unsupported tenant Update.
-	model := tenantResourceModelFromDto(tenant, nil, nil, true)
+	// Carry null rather than the backend's effective quotas: a migrated configuration that omits quotas
+	// plans null, and a spec quota diff would route to Update, which the meshTenant API does not support.
+	model := tenantResourceModelFromDto(tenant, nil, true)
 	resp.Diagnostics.Append(generic.Set(ctx, &resp.State, model, tenantConverterOptions()...)...)
 }
 
@@ -474,19 +469,6 @@ func tenantBodyAttributes() map[string]schema.Attribute {
 								MarkdownDescription: "The requested quota value.",
 								Required:            true,
 							},
-						},
-					},
-				},
-				"quotas": schema.SetNestedAttribute{
-					MarkdownDescription: "Deprecated: use `requested_quotas` instead, which models quotas as a " +
-						"`key -> value` map. Providing both is rejected when they disagree. Quotas to apply to the tenant " +
-						"at creation as a list of `{key, value}` entries.",
-					DeprecationMessage: "Use `requested_quotas` (a key -> value map) instead.",
-					Optional:           true,
-					NestedObject: schema.NestedAttributeObject{
-						Attributes: map[string]schema.Attribute{
-							"key":   schema.StringAttribute{Required: true},
-							"value": schema.Int64Attribute{Required: true},
 						},
 					},
 				},

--- a/internal/provider/tenant_state_upgrade_test.go
+++ b/internal/provider/tenant_state_upgrade_test.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"testing"
+)
+
+// State as v0.24.3 wrote it, for a configuration that requested quotas through the deprecated list-form
+// spec.quotas.
+const tenantStateV1DeprecatedQuotas = `{
+  "ref": {"uuid": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f", "kind": "meshTenant"},
+  "metadata": {
+    "uuid": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+    "owned_by_workspace": "my-workspace",
+    "owned_by_project": "my-project"
+  },
+  "spec": {
+    "platform_ref": {"uuid": "a2b7cf9c-8e2a-4b0d-9e6f-1c4b9de3a111", "kind": "meshPlatform"},
+    "landing_zone_ref": {"name": "example-default", "kind": "meshLandingZone"},
+    "platform_tenant_id": "cloud-tenant-4763-4526189",
+    "requested_quotas": null,
+    "quotas": [{"key": "limits.cpu", "value": 4}, {"key": "limits.memory", "value": 8}]
+  },
+  "status": {
+    "tenant_name": "my-workspace.my-project.azure.germanywestcentral",
+    "platform_type_identifier": "azure",
+    "platform_workspace_id": null,
+    "tags": {},
+    "applied_quotas": {"limits.cpu": {"value": 4}, "limits.memory": {"value": 8}}
+  },
+  "wait_for_completion": true
+}`
+
+const tenantStateV1RequestedQuotas = `{
+  "ref": {"uuid": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f", "kind": "meshTenant"},
+  "metadata": {
+    "uuid": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+    "owned_by_workspace": "my-workspace",
+    "owned_by_project": "my-project"
+  },
+  "spec": {
+    "platform_ref": {"uuid": "a2b7cf9c-8e2a-4b0d-9e6f-1c4b9de3a111", "kind": "meshPlatform"},
+    "landing_zone_ref": null,
+    "platform_tenant_id": null,
+    "requested_quotas": {"limits.cpu": {"value": 4}},
+    "quotas": null
+  },
+  "status": {
+    "tenant_name": "my-workspace.my-project.azure.germanywestcentral",
+    "platform_type_identifier": "azure",
+    "platform_workspace_id": null,
+    "tags": {},
+    "applied_quotas": {"limits.cpu": {"value": 4}}
+  },
+  "wait_for_completion": false
+}`
+
+func TestTenantUpgradeStateFromV1(t *testing.T) {
+	if !HasNestedAttributeForTest(t, tenantSchemaV1Once(), "spec", "quotas") {
+		t.Error("prior v1 schema lost spec.quotas; state written by v0.24.3 carries that key")
+	}
+	if HasNestedAttributeForTest(t, ResourceSchemaForTest(t, &tenantResource{}), "spec", "quotas") {
+		t.Fatal("current schema still declares spec.quotas")
+	}
+
+	t.Run("translates the deprecated list into requested_quotas", func(t *testing.T) {
+		var upgraded tenantResourceModel
+		diags := UpgradeResourceStateFromJSON(t, &tenantResource{}, 1, tenantStateV1DeprecatedQuotas, &upgraded)
+		if diags.HasError() {
+			t.Fatalf("upgrade produced errors: %s", diags)
+		}
+
+		want := map[string]int64{"limits.cpu": 4, "limits.memory": 8}
+		if len(upgraded.Spec.RequestedQuotas) != len(want) {
+			t.Fatalf("requested_quotas not translated, got %v", upgraded.Spec.RequestedQuotas)
+		}
+		for k, v := range want {
+			if got := upgraded.Spec.RequestedQuotas[k]; got.Value != v {
+				t.Errorf("requested_quotas[%q] = %d, want %d", k, got.Value, v)
+			}
+		}
+
+		if upgraded.Metadata.Uuid != "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f" {
+			t.Errorf("metadata not carried over, got %+v", upgraded.Metadata)
+		}
+		if upgraded.Spec.PlatformRef.Uuid != "a2b7cf9c-8e2a-4b0d-9e6f-1c4b9de3a111" {
+			t.Errorf("platform_ref not carried over, got %+v", upgraded.Spec.PlatformRef)
+		}
+		if upgraded.Spec.LandingZoneRef == nil || upgraded.Spec.LandingZoneRef.Name != "example-default" {
+			t.Errorf("landing_zone_ref not carried over, got %+v", upgraded.Spec.LandingZoneRef)
+		}
+		if upgraded.Status.TenantName != "my-workspace.my-project.azure.germanywestcentral" {
+			t.Errorf("status not carried over, got %+v", upgraded.Status)
+		}
+		if !upgraded.WaitForCompletion {
+			t.Error("wait_for_completion not carried over")
+		}
+	})
+
+	t.Run("keeps an existing requested_quotas map", func(t *testing.T) {
+		var upgraded tenantResourceModel
+		diags := UpgradeResourceStateFromJSON(t, &tenantResource{}, 1, tenantStateV1RequestedQuotas, &upgraded)
+		if diags.HasError() {
+			t.Fatalf("upgrade produced errors: %s", diags)
+		}
+
+		if len(upgraded.Spec.RequestedQuotas) != 1 || upgraded.Spec.RequestedQuotas["limits.cpu"].Value != 4 {
+			t.Errorf("requested_quotas not preserved, got %v", upgraded.Spec.RequestedQuotas)
+		}
+		if upgraded.Spec.LandingZoneRef != nil {
+			t.Errorf("null landing_zone_ref became %+v", upgraded.Spec.LandingZoneRef)
+		}
+		if upgraded.WaitForCompletion {
+			t.Error("wait_for_completion flipped to true")
+		}
+	})
+
+	t.Run("leaves requested_quotas null when neither field was set", func(t *testing.T) {
+		state := `{
+      "ref": {"uuid": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f", "kind": "meshTenant"},
+      "metadata": {"uuid": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f", "owned_by_workspace": "w", "owned_by_project": "p"},
+      "spec": {
+        "platform_ref": {"uuid": "a2b7cf9c-8e2a-4b0d-9e6f-1c4b9de3a111", "kind": "meshPlatform"},
+        "landing_zone_ref": null, "platform_tenant_id": null, "requested_quotas": null, "quotas": null
+      },
+      "status": {
+        "tenant_name": "w.p.azure.gwc", "platform_type_identifier": "azure",
+        "platform_workspace_id": null, "tags": {}, "applied_quotas": {}
+      },
+      "wait_for_completion": true
+    }`
+
+		var upgraded tenantResourceModel
+		diags := UpgradeResourceStateFromJSON(t, &tenantResource{}, 1, state, &upgraded)
+		if diags.HasError() {
+			t.Fatalf("upgrade produced errors: %s", diags)
+		}
+		if upgraded.Spec.RequestedQuotas != nil {
+			t.Errorf("requested_quotas became %v, want nil", upgraded.Spec.RequestedQuotas)
+		}
+	})
+}

--- a/internal/provider/tenant_upgrade.go
+++ b/internal/provider/tenant_upgrade.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"maps"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	"github.com/meshcloud/terraform-provider-meshstack/client"
+	clientTypes "github.com/meshcloud/terraform-provider-meshstack/client/types"
+	"github.com/meshcloud/terraform-provider-meshstack/internal/types/generic"
+)
+
+// tenantSpecV1 mirrors client.MeshTenantSpec as it stood while the deprecated list-form spec.quotas
+// still existed. Keep it a standalone struct: reading prior state through the current spec is the bug
+// that broke the landing zone's 0 -> 1 upgrade.
+type tenantSpecV1 struct {
+	PlatformRef      client.UuidRef                          `tfsdk:"platform_ref"`
+	PlatformTenantId *string                                 `tfsdk:"platform_tenant_id"`
+	LandingZoneRef   *client.NamedRef                        `tfsdk:"landing_zone_ref"`
+	RequestedQuotas  map[string]client.RequestQuotaValue     `tfsdk:"requested_quotas"`
+	Quotas           clientTypes.Set[client.MeshTenantQuota] `tfsdk:"quotas"`
+}
+
+type tenantResourceModelV1 struct {
+	Ref               tenantRef                 `tfsdk:"ref"`
+	Metadata          client.MeshTenantMetadata `tfsdk:"metadata"`
+	Spec              tenantSpecV1              `tfsdk:"spec"`
+	Status            client.MeshTenantStatus   `tfsdk:"status"`
+	WaitForCompletion bool                      `tfsdk:"wait_for_completion"`
+}
+
+// tenantSchemaV1Once builds the schema version 1 shape for the state upgrader: the current schema with
+// the removed spec.quotas attribute added back.
+var tenantSchemaV1Once = sync.OnceValue(func() schema.Schema {
+	var schemaResp resource.SchemaResponse
+	(&tenantResource{}).Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	s := schemaResp.Schema
+	s.Version = 1
+
+	spec, ok := s.Attributes["spec"].(schema.SingleNestedAttribute)
+	if !ok {
+		panic("tenant spec attribute is not a SingleNestedAttribute")
+	}
+	spec.Attributes = maps.Clone(spec.Attributes)
+	spec.Attributes["quotas"] = schema.SetNestedAttribute{
+		Optional: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"key":   schema.StringAttribute{Required: true},
+				"value": schema.Int64Attribute{Required: true},
+			},
+		},
+	}
+	s.Attributes = maps.Clone(s.Attributes)
+	s.Attributes["spec"] = spec
+
+	return s
+})
+
+// upgradeFromV1 migrates state written while spec.quotas existed. State that already carries
+// spec.requested_quotas keeps it, because v0.24.3 accepted both fields only when they described the
+// same quotas.
+func (r *tenantResource) upgradeFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	prior := generic.Get[tenantResourceModelV1](ctx, req.State, &resp.Diagnostics, tenantConverterOptions()...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestedQuotas := prior.Spec.RequestedQuotas
+	if len(requestedQuotas) == 0 {
+		requestedQuotas = quotaListToRequestedMap(prior.Spec.Quotas)
+	}
+
+	resp.Diagnostics.Append(generic.Set(ctx, &resp.State, tenantResourceModel{
+		Ref:      prior.Ref,
+		Metadata: prior.Metadata,
+		Spec: client.MeshTenantSpec{
+			PlatformRef:      prior.Spec.PlatformRef,
+			PlatformTenantId: prior.Spec.PlatformTenantId,
+			LandingZoneRef:   prior.Spec.LandingZoneRef,
+			RequestedQuotas:  requestedQuotas,
+		},
+		Status:            prior.Status,
+		WaitForCompletion: prior.WaitForCompletion,
+	}, tenantConverterOptions()...)...)
+}

--- a/internal/provider/tenants_data_source.go
+++ b/internal/provider/tenants_data_source.go
@@ -112,17 +112,6 @@ func (d *tenantsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 										},
 									},
 								},
-								"quotas": schema.ListNestedAttribute{
-									MarkdownDescription: "Deprecated: use `requested_quotas` instead. The requested quotas as a list of `{key, value}` entries.",
-									DeprecationMessage:  "Use `requested_quotas` (a key -> value map) instead.",
-									Computed:            true,
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"key":   schema.StringAttribute{Computed: true},
-											"value": schema.Int64Attribute{Computed: true},
-										},
-									},
-								},
 							},
 						},
 						"status": schema.SingleNestedAttribute{


### PR DESCRIPTION
Removes the deprecated list-form `spec.quotas` from the unsuffixed `meshstack_tenant` resource, its data
source and `meshstack_tenants`, so the provider stops sending and modelling a field the meshTenant API
deprecated.

Ships in **`v0.24.4`**, whose changelog section already holds the building block ref changes on `main`.
It only stops *using* a deprecated field that the API still accepts, so it needs **no newer meshStack
version**: the floor stays at `2026.30.0`, which v0.24.3 already requires.

This is the predecessor to #247, the GA cutover. The quota cleanup does not depend on the GA backend, so
it merges and releases on its own, and #247 keeps to what the GA cutover really is: dropping the
`-preview` suffix and deleting the deprecated resource.

## Scope

Only the unsuffixed, ref-based `meshstack_tenant` is touched. The deprecated `meshstack_tenant_v4` keeps
its own `spec.quotas` and the shared `MeshTenantQuota` DTO it needs: #247 removes that resource
completely once the API goes GA, so cleaning it up here would be wasted work.

## Breaking change, and why a patch release can carry it

`quotas = [...]` is no longer a valid argument on `meshstack_tenant`. Request quotas as a map instead:

```hcl
# before
quotas = [{ key = "limits.cpu", value = 4 }]
# after
requested_quotas = { "limits.cpu" = { value = 4 } }
```

Existing state migrates automatically (`meshstack_tenant` schema version 1 → 2). The upgrader
**translates** a quota recorded under `spec.quotas` into `spec.requested_quotas` rather than dropping it,
so a configuration that restates the same quotas in the map form plans no change. That is the reason for
translating: `spec.requested_quotas` is create-only, so a spurious diff would show up as a rejected
quota change rather than as a no-op. The `moved` mover from `meshstack_tenant_v4` translates the same
way.

The upgrader's `PriorSchema` is the old shape — the current schema with `spec.quotas` added back — and
not the current schema. Reading prior state through the current shape is the bug that broke the
landing-zone state upgrade in v0.24.1.

## Tests

- `TestTenantUpgradeStateFromV1` covers all three state shapes: the deprecated list (translated), an
  already-migrated `requested_quotas` map (preserved), and neither field set (stays null, so no diff).
  It also asserts that the prior schema still declares `spec.quotas` while the current one does not.
- `TestQuotaListToRequestedMap` covers the translation helper, including the nil-for-empty case.
- The existing tenant acceptance suite (`quotas`, `quotas_out_of_range`, `quotas_change_rejected`,
  `quotas_landing_zone_defaults`, `quotas_above_auto_approval_threshold_admin_key`) already drives
  `requested_quotas` only, so it covers this change unchanged.

Tracking: CU-86c0j0r7q.

