### PR TITLE
ci: stream acceptance test results so a cut run says where it stopped

### DIFF
--- a/.github/scripts/run-acceptance-tests.sh
+++ b/.github/scripts/run-acceptance-tests.sh
@@ -26,6 +26,13 @@ export TF_ACC_TERRAFORM_PATH
 # self-hosted-runner truncation can cut the test process short while this step still exits 0, which
 # would otherwise pass as a green run. pipefail (set above) keeps a genuine test failure propagating
 # through the pipe.
-go tool gotestsum --junitfile junit-acc.xml --format testdox -- \
+#
+# `testname` prints each test as it finishes; `testdox` buffers a package's whole report until that
+# package ends. Since nearly every acceptance test is t.Parallel(), testdox meant ./internal/provider
+# emitted nothing for the ~5 minutes it runs and then everything at once — so a run cut short left a
+# log holding only the empty-package headers, identical no matter where it died. Streaming makes the
+# next truncation say which test it reached. The final "DONE N tests" summary the verify step greps
+# for is printed by both formats.
+go tool gotestsum --junitfile junit-acc.xml --format testname -- \
   -coverpkg=./... -count=1 -timeout 10m -run 'TestAcc' ./... \
   -args -test.gocoverdir="$PWD/covdata/acc" 2>&1 | tee acc-output.log


### PR DESCRIPTION
## What

One-word change in `.github/scripts/run-acceptance-tests.sh`: `gotestsum --format testdox` → `--format testname`.

## Why

Chasing repeated `Verify acceptance run completed` failures on #273, I watched `acc-output.log` inside the live job container:

```
12:27:05   log = 1682 bytes,  go test still running
12:27:06   step completes,    full output + "DONE 142 tests"
```

`testdox` buffers a package's report until the package ends. Since nearly every acceptance test is `t.Parallel()`, `./internal/provider` emits **nothing** for the ~5 minutes it runs, then everything at once. So for the whole run the log holds only the 1.7 KB of empty-package headers — and a truncated run leaves precisely that file, identical no matter where it died. The guard could tell us a run was cut, never where.

Measured, same three parallel sleeping tests, timestamping each line as it arrives:

| format | output arrival |
|---|---|
| `testdox` | all lines at `05.02–05.03` — one burst at the end |
| `testname` | `TestAccSlowA` at `11.18`, B/C at `14.18` — during the run |

## Cut-off detection is unchanged

`DONE N tests in …` is printed by both formats, and I checked the guard's own regex against real `testname` output:

```
$ grep -qE '^DONE [0-9]+ tests' out.log && echo "GUARD PASSES with testname"
GUARD PASSES with testname
DONE 1 tests in 2.003s
```

## Not a fix for the truncation itself

Worth being explicit: this does not stop runs being cut. I looked for a ~5 minute timeout and there is none — kubelet `streamingConnectionIdleTimeout` is `4h0m0s`, the acceptance job sets no `timeout-minutes` (GitHub default 360m), the only step timeout is `Wait for backend to be ready: 8m`, and `go test -timeout` is 10m. The clustering of failures around 5m is how long the suite takes, not a ceiling.

The likelier cause is runner-infra: `mesh-runners` schedules onto GKE **spot** nodes, and during one debugging session the entire spot pool was reclaimed inside ~30 minutes. The workflow pods also run with `requests: {cpu: 0, memory: 0}` against `limits: 24Gi` × 11 containers on a 32 GB node, so they are first out under node pressure. Both are worth addressing separately; this PR only makes the next occurrence diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)