### PR TITLE
refactor: WIP test refactoring for meshProject resource

### DIFF
--- a/.agents/skills/resource-development/REFERENCE.md
+++ b/.agents/skills/resource-development/REFERENCE.md
@@ -154,10 +154,12 @@ Use these instead of raw `knownvalue` functions
 ## Worked TestAcc test (create → update → import)
 
 A good test is multi-step, uses the builder, and asserts with `plancheck` (the planned action) +
-`statecheck`/`xknownvalue` (resulting state):
+`statecheck`/`xknownvalue` (resulting state). The builder-based snippet below is the shape of every
+not-yet-migrated test (live example: `workspace_resource_test.go`); for the per-step example-file
+shape that replaces it, see SKILL.md → Migration off `testconfig` and `project_resource_test.go`:
 
 ```go
-func TestAccProject(t *testing.T) {
+func TestAccProjectWithTestconfig(t *testing.T) {
     config, resourceAddress, workspaceAddr := testconfig.ProjectAndWorkspace(t)
     updateConfig := config.WithFirstBlock(
         testconfig.Descend("spec", "display_name")(testconfig.SetString("Updated Display Name")),

--- a/.agents/skills/resource-development/SKILL.md
+++ b/.agents/skills/resource-development/SKILL.md
@@ -23,7 +23,8 @@ Mid-complexity, clean, and complete — prefer these over the large `building_bl
 | Example `.tf` (simple) | `examples/resources/meshstack_project/` (`resource.tf`, `import-by-string-id.tf`) |
 | Example `.tf` (complex, multi-file + `test-support_*`) | `examples/resources/meshstack_building_block_definition/` |
 | testconfig builder | `internal/provider/acctest/testconfig/build_project.go` |
-| Resource test (create→update→import) | `internal/provider/project_resource_test.go` |
+| Resource test, per-step example files (target state) | `internal/provider/project_resource_test.go` + `examples/resources/meshstack_project/resource-test-*.tf` |
+| Resource test, testconfig builder (still the majority) | `internal/provider/workspace_resource_test.go` |
 | Data source test | `internal/provider/project_data_source_test.go` |
 | Named subtests for multiple examples | `internal/provider/integration_resource_test.go` |
 | State-check helpers | `internal/provider/acctest/xknownvalue/{not_empty_string,ref,map}.go` |
@@ -111,7 +112,25 @@ a worked `build_project.go` are in `REFERENCE.md`.
 A good test is multi-step (create → update → import), uses the builder, and asserts with
 `plancheck` (the planned action) + `statecheck`/`xknownvalue` (resulting state). Prefer the
 `xknownvalue` helpers (`NotEmptyString`, `Ref`, `MapExact`) over raw `knownvalue` where they fit.
-See `REFERENCE.md` for the full `TestAccProject` example.
+See `REFERENCE.md` for the full worked example.
+
+### Migration off `testconfig` (in progress)
+
+The `testconfig` builders are being retired: instead of mutating an example's HCL in Go, each test
+step gets its own checked-in config file next to the documented example. `meshstack_project` is
+migrated and is the reference; every other resource/data source still uses `testconfig` and its
+builders stay until it is migrated too. The migrated shape:
+
+- `examples/resources/meshstack_<name>/resource-test-<index>.tf` — the example as step `<index>`
+  applies it (data sources swapped for test-created resources, names built from `var.suffix`).
+- `examples/resources/meshstack_<name>/test-support_<name>.tf` — the prerequisites those step files
+  reference, plus the `variable` blocks the test fills.
+- The test assembles a step with `examples.Resource.TestStepConfig(t, "<name>", <index>, "<support>"…)`
+  and passes the random suffix via `ConfigVariables`; resource addresses are plain string constants
+  (`meshstack_project.example`) instead of extracted `Traversal`s.
+
+See `examples/README.md` for the file conventions, including the `-test-` filter that keeps the step
+files out of the generated docs.
 
 ## Data source test
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,3 +12,24 @@ This is useful for creating examples that can run and/or ar testable even if som
 * `data-sources/<full resource name>/data-source.tf` example file for the named data source page
 * `resources/<full resource name>/resource.tf` example file for the named data source page
 * `resources/<<full resource name>>/import.sh`
+
+## Files used by the acceptance tests
+
+Beyond the documented example, a resource/data source directory holds the configs its acceptance
+test applies:
+
+* `resource-test-<index>.tf` / `data-source-test-<index>.tf` — the example as one test step applies
+  it: same block, but with the documented data sources swapped for resources the test creates and
+  names carrying the run's random `var.suffix`. One file per step, numbered from 1; the index is
+  what links the file to the step in the test (`examples.Resource.TestStepConfig(t, name, index, …)`).
+* `test-support_<name>.tf` — the prerequisites those step files reference (owning workspace, tag
+  definitions, …) plus the `variable` declarations the test fills via `ConfigVariables`. A step
+  config is its `resource-test-<index>.tf` followed by the support files the test names.
+
+`meshstack_project` is the reference for this layout.
+
+Note that the docs tool globs `resource*.tf` / `data-source*.tf`, so `templates/resources.md.tmpl`
+skips any example path containing `-test-`. Without that filter the step configs would show up as
+documented examples in the registry. Data sources currently render with the tool's built-in
+template, so the first `data-source-test-<index>.tf` also needs a `templates/data-sources.md.tmpl`
+carrying the same filter.

--- a/examples/embed.go
+++ b/examples/embed.go
@@ -2,6 +2,7 @@ package examples
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"path"
 	"strings"
@@ -58,4 +59,19 @@ func (e Example) Read(t *testing.T, name string, fileNameParts ...string) []byte
 	content, err := fsys.ReadFile(filePath)
 	require.NoErrorf(t, err, "cannot read examples config file %s:", filePath)
 	return content
+}
+
+// TestStepConfig assembles the HCL for one acceptance test step: the step's own variant of the
+// example (<resource|data-source>-test-<index>.tf) followed by the named test-support files
+// (test-support_<name>.tf) holding the prerequisites that variant references.
+//
+// One file per step keeps every applied config readable as plain HCL and diffable against the
+// documented example; the index is the link between the file and the step that uses it.
+func (e Example) TestStepConfig(t *testing.T, name string, index int, supportNames ...string) string {
+	t.Helper()
+	parts := []string{string(e.Read(t, name, fmt.Sprintf("-test-%d", index)))}
+	for _, supportName := range supportNames {
+		parts = append(parts, string(e.Read(t, name, "test-support", "_"+supportName)))
+	}
+	return strings.Join(parts, "\n")
 }

--- a/examples/resources/meshstack_project/resource-test-1.tf
+++ b/examples/resources/meshstack_project/resource-test-1.tf
@@ -1,0 +1,17 @@
+resource "meshstack_project" "example" {
+  metadata = {
+    name               = "test-proj-${var.suffix}"
+    owned_by_workspace = meshstack_workspace.example.metadata.name
+  }
+  spec = {
+    payment_method_identifier = meshstack_payment_method.example.metadata.name
+    display_name              = "My Project's Display Name"
+    tags = {
+      (meshstack_tag_definition.project_tag.spec.key) = [
+        "tag-value1",
+        "tag-value2",
+        "tag-valueN"
+      ]
+    }
+  }
+}

--- a/examples/resources/meshstack_project/resource-test-2.tf
+++ b/examples/resources/meshstack_project/resource-test-2.tf
@@ -1,0 +1,17 @@
+resource "meshstack_project" "example" {
+  metadata = {
+    name               = "test-proj-${var.suffix}"
+    owned_by_workspace = meshstack_workspace.example.metadata.name
+  }
+  spec = {
+    payment_method_identifier = meshstack_payment_method.example.metadata.name
+    display_name              = "Updated Display Name"
+    tags = {
+      (meshstack_tag_definition.project_tag.spec.key) = [
+        "tag-value1",
+        "tag-value2",
+        "tag-valueN"
+      ]
+    }
+  }
+}

--- a/examples/resources/meshstack_project/resource-test-3.tf
+++ b/examples/resources/meshstack_project/resource-test-3.tf
@@ -1,0 +1,17 @@
+resource "meshstack_project" "example" {
+  # No attribute references the restricted tag definition, so without depends_on the backend could
+  # still be missing it when the project is created — and inject nothing.
+  depends_on = [meshstack_tag_definition.restricted_tag]
+
+  metadata = {
+    name               = "test-proj-${var.suffix}"
+    owned_by_workspace = meshstack_workspace.example.metadata.name
+  }
+  spec = {
+    payment_method_identifier = meshstack_payment_method.example.metadata.name
+    display_name              = "My Project's Display Name"
+    tags = {
+      (meshstack_tag_definition.project_tag.spec.key) = ["blue"]
+    }
+  }
+}

--- a/examples/resources/meshstack_project/test-support_prerequisites.tf
+++ b/examples/resources/meshstack_project/test-support_prerequisites.tf
@@ -1,0 +1,71 @@
+# Prerequisites for every TestAccProject step: the owning workspace, the payment method the project
+# bills to and the tag definitions the declared tags reference. They replace the data sources of
+# resource.tf, and their names carry the run's random suffix so parallel runs never collide.
+
+variable "suffix" {
+  type = string
+}
+
+resource "meshstack_workspace" "example" {
+  metadata = {
+    name = "test-ws-${var.suffix}"
+    tags = {
+      (meshstack_tag_definition.workspace_tag.spec.key) = ["12345"]
+    }
+  }
+  spec = {
+    display_name = "My Workspace's Display Name"
+  }
+}
+
+resource "meshstack_payment_method" "example" {
+  metadata = {
+    name               = "test-pm-${var.suffix}"
+    owned_by_workspace = meshstack_workspace.example.metadata.name
+  }
+
+  spec = {
+    display_name    = "My Payment Method"
+    expiration_date = "2025-12-31"
+    amount          = 10000
+    tags = {
+      (meshstack_tag_definition.payment_method_tag.spec.key) = ["0000"]
+    }
+  }
+}
+
+resource "meshstack_tag_definition" "workspace_tag" {
+  spec = {
+    target_kind  = "meshWorkspace"
+    key          = "test-key-workspace-${var.suffix}"
+    display_name = "Test Tag"
+
+    value_type = {
+      string = {}
+    }
+  }
+}
+
+resource "meshstack_tag_definition" "payment_method_tag" {
+  spec = {
+    target_kind  = "meshPaymentMethod"
+    key          = "test-key-payment-method-${var.suffix}"
+    display_name = "Test Tag"
+
+    value_type = {
+      string = {}
+    }
+  }
+}
+
+resource "meshstack_tag_definition" "project_tag" {
+  spec = {
+    target_kind  = "meshProject"
+    key          = "test-key-project-${var.suffix}"
+    display_name = "Test Tag"
+
+    value_type = {
+      string = {}
+    }
+  }
+}

--- a/examples/resources/meshstack_project/test-support_restricted-tag.tf
+++ b/examples/resources/meshstack_project/test-support_restricted-tag.tf
@@ -1,0 +1,17 @@
+# Used by TestAccProject/restricted_default_tag (resource-test-3.tf): on create the backend injects
+# this default into every project, whether or not the caller declares the tag.
+
+resource "meshstack_tag_definition" "restricted_tag" {
+  spec = {
+    target_kind  = "meshProject"
+    key          = "test-key-restricted-project-${var.suffix}"
+    display_name = "Restricted Test Tag"
+    restricted   = true
+
+    value_type = {
+      string = {
+        default_value = "injected-default"
+      }
+    }
+  }
+}

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -11,9 +13,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/meshcloud/terraform-provider-meshstack/client"
-	"github.com/meshcloud/terraform-provider-meshstack/internal/provider/acctest/testconfig"
+	"github.com/meshcloud/terraform-provider-meshstack/examples"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/provider/acctest/xknownvalue"
+)
+
+// Addresses and the tag key prefix of the blocks in
+// examples/resources/meshstack_project/resource-test-*.tf and its test-support files.
+const (
+	projectResourceAddr          = "meshstack_project.example"
+	projectWorkspaceResourceAddr = "meshstack_workspace.example"
+	projectTagKeyPrefix          = "test-key-project-"
 )
 
 func TestAccProject(t *testing.T) {
@@ -25,20 +34,16 @@ func TestAccProject(t *testing.T) {
 			t.Skip("relies on the backend injecting a restricted tag's default value on create")
 		}
 
-		tagConfig, tagAddr, tagKey := testconfig.TagDefinition(t, client.MeshObjectKind.Project)
-		restrictedTagConfig, _, _ := testconfig.RestrictedTagDefinitionWithDefault(t, client.MeshObjectKind.Project, "injected-default")
-		config, resourceAddress, _ := testconfig.ProjectAndWorkspace(t)
-		config = config.Join(tagConfig, restrictedTagConfig).WithFirstBlock(
-			testconfig.Descend("spec", "tags")(testconfig.SetRawExpr(`{ (%s) = ["blue"] }`, tagAddr.Join("spec", "key"))),
-		)
+		suffix := acctest.RandString(8)
 
 		ApplyAndTest(t, resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config: config.String(),
+					Config:          examples.Resource.TestStepConfig(t, "project", 3, "prerequisites", "restricted-tag"),
+					ConfigVariables: projectConfigVariables(suffix),
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec").AtMapKey("tags"), knownvalue.MapExact(map[string]knownvalue.Check{
-							tagKey: knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("blue")}),
+						statecheck.ExpectKnownValue(projectResourceAddr, tfjsonpath.New("spec").AtMapKey("tags"), knownvalue.MapExact(map[string]knownvalue.Check{
+							projectTagKeyPrefix + suffix: knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("blue")}),
 						})),
 					},
 					// Refresh reads back the injected superset; reconcileTrackedTags must reconcile it
@@ -51,54 +56,57 @@ func TestAccProject(t *testing.T) {
 		})
 	})
 
-	config, resourceAddress, workspaceAddr := testconfig.ProjectAndWorkspace(t)
-
-	updateConfig := config.WithFirstBlock(
-		testconfig.Descend("spec", "display_name")(testconfig.SetString("Updated Display Name")),
-	)
+	vars := projectConfigVariables(acctest.RandString(8))
 
 	ApplyAndTest(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
-				Config: config.String(),
+				Config:          examples.Resource.TestStepConfig(t, "project", 1, "prerequisites"),
+				ConfigVariables: vars,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceAddress.String(), plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(projectResourceAddr, plancheck.ResourceActionCreate),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata").AtMapKey("name"), xknownvalue.NotEmptyString()),
-					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata").AtMapKey("owned_by_workspace"), xknownvalue.NotEmptyString()),
-					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec").AtMapKey("display_name"), knownvalue.StringExact("My Project's Display Name")),
+					statecheck.ExpectKnownValue(projectResourceAddr, tfjsonpath.New("metadata").AtMapKey("name"), xknownvalue.NotEmptyString()),
+					statecheck.ExpectKnownValue(projectResourceAddr, tfjsonpath.New("metadata").AtMapKey("owned_by_workspace"), xknownvalue.NotEmptyString()),
+					statecheck.ExpectKnownValue(projectResourceAddr, tfjsonpath.New("spec").AtMapKey("display_name"), knownvalue.StringExact("My Project's Display Name")),
 				},
 			},
 			{
-				Config: updateConfig.String(),
+				Config:          examples.Resource.TestStepConfig(t, "project", 2, "prerequisites"),
+				ConfigVariables: vars,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceAddress.String(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(projectResourceAddr, plancheck.ResourceActionUpdate),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec").AtMapKey("display_name"), knownvalue.StringExact("Updated Display Name")),
+					statecheck.ExpectKnownValue(projectResourceAddr, tfjsonpath.New("spec").AtMapKey("display_name"), knownvalue.StringExact("Updated Display Name")),
 				},
 			},
 			{
-				ResourceName:    resourceAddress.String(),
+				ResourceName:    projectResourceAddr,
 				ImportState:     true,
 				ImportStateKind: resource.ImportBlockWithID,
+				ConfigVariables: vars,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs := s.RootModule().Resources[resourceAddress.String()]
+					rs := s.RootModule().Resources[projectResourceAddr]
 					if rs == nil {
-						return "", fmt.Errorf("resource not found: %s", resourceAddress.String())
+						return "", fmt.Errorf("resource not found: %s", projectResourceAddr)
 					}
-					ws := s.RootModule().Resources[workspaceAddr.String()]
+					ws := s.RootModule().Resources[projectWorkspaceResourceAddr]
 					if ws == nil {
-						return "", fmt.Errorf("workspace resource not found: %s", workspaceAddr.String())
+						return "", fmt.Errorf("workspace resource not found: %s", projectWorkspaceResourceAddr)
 					}
 					return ws.Primary.Attributes["metadata.name"] + "." + rs.Primary.Attributes["metadata.name"], nil
 				},
 			},
 		},
 	})
+}
+
+func projectConfigVariables(suffix string) tfconfig.Variables {
+	return tfconfig.Variables{"suffix": tfconfig.StringVariable(suffix)}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -142,6 +142,9 @@ func dumpStepConfigs(t *testing.T, target string, steps []resource.TestStep) {
 		require.NoError(t, os.MkdirAll(stepDir, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(stepDir, "main.tf"), []byte(step.Config), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(stepDir, "provider.tf"), []byte(scratchProviderTf), 0o644))
+		// A step whose config declares variables (e.g. the random name suffix) needs their values
+		// alongside it; Write emits an .auto.tfvars.json file, which tofu/terraform loads on its own.
+		require.NoError(t, step.ConfigVariables.Write(stepDir))
 		written++
 	}
 

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -12,10 +12,14 @@ description: |-
 
 {{ if .HasExamples -}}
 ## Example Usage
-
+{{- /* tfplugindocs globs resource*.tf, which also matches the resource-test-<index>.tf variants the
+       acceptance tests apply. Those are not documentation, so skip them. We use split+len because
+       tfplugindocs does not expose a "contains" template function (see the secret markers below). */ -}}
 {{- range .ExampleFiles }}
+{{- if eq (len (split . "-test-")) 1 }}
 
 {{ tffile . }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
First step of moving the acceptance-test infrastructure off the `testconfig` package and its builder
pattern, so that package can eventually be deleted. Scoped to **`meshstack_project`** only.

## What changed

Instead of loading `resource.tf` and mutating its HCL in Go, each test step now applies its own
checked-in config file next to the documented example:

| File | Role |
|---|---|
| `examples/resources/meshstack_project/resource-test-1.tf` | step 1, create — `resource.tf` with the data sources swapped for test-created resources |
| `resource-test-2.tf` | step 2, update — identical except `spec.display_name` |
| `resource-test-3.tf` | the `restricted_default_tag` subtest — one declared tag value |
| `test-support_prerequisites.tf` | workspace, payment method, the three tag definitions, `variable "suffix"` |
| `test-support_restricted-tag.tf` | the restricted tag definition whose default the backend injects |

`resource.tf` and `import-by-string-id.tf` are untouched — examples keep serving documentation *and*
tests, as before. A step's config is its `resource-test-<index>.tf` plus the support files the test
names: `examples.Resource.TestStepConfig(t, "project", 1, "prerequisites")`. The index in that call
is what links the step to its file.

## Notes for the reviewer

- **Randomization now goes through `ConfigVariables`.** Static files can't carry a random suffix, so
  names are `test-proj-${var.suffix}` and the test passes the value in — the same mechanism
  `test-support_other_provider.tf` already used. State independence is preserved and no HCL is
  manipulated in Go anymore. The one Go↔HCL coupling left is `projectTagKeyPrefix`, which has to
  match the tag key in the support file.
- **The docs glob was a trap.** tfplugindocs globs `resource*.tf`, so the step files landed in
  `docs/resources/project.md` (+69 lines). `templates/resources.md.tmpl` now skips example paths
  containing `-test-`; verified that docs regenerate byte-identical with the filter and do change
  without it. Data sources render with the tool's built-in template, so the first
  `data-source-test-<index>.tf` will need a `templates/data-sources.md.tmpl` with the same filter —
  noted in `examples/README.md`.
- **Prerequisites live in support files, not duplicated per step.** Self-contained step files would
  mean copying the whole prerequisite stack into each one — untenable for something like
  `building_block`. This keeps every step file a readable diff of `resource.tf`.
- **`resource-test-3.tf` adds `depends_on`** for the restricted tag definition. Nothing referenced
  it, so Terraform was free to create it after the project and the backend would inject nothing — a
  latent race in the test as it stood.
- **`testconfig.Project` / `ProjectAndWorkspace` stay.** Eight other tests still use them
  (`project_*_binding`, `tenant`, `building_block`, the project data sources).
- The scratch dump (`MESHSTACK_SCRATCH_DUMP`) now writes the step's variables alongside `main.tf`, so
  a dumped config stays runnable standalone.
- No CHANGELOG entry: test infrastructure only, published docs unchanged.

## Verification

- `go test ./...` (mock mode) green, `task lint` 0 issues, `terraform fmt -recursive ./examples/` clean.
- Docs regenerate with no diff.
- `resource-test-3.tf` was exercised by temporarily flipping its mock skip, confirming it applies and
  asserts cleanly; the skip is restored.
- **Acceptance suite not run** (no local backend available in this session) — `resource-test-3.tf`
  only means anything there. Also worth confirming the backend is happy with
  `test-support_prerequisites.tf`, which keeps the tag definitions on the workspace and payment
  method faithful to what the builders produced rather than trimming them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)