### PR TITLE
test: serialize acceptance tests that create restricted default tags

### DIFF
--- a/internal/provider/building_block_definition_resource_test.go
+++ b/internal/provider/building_block_definition_resource_test.go
@@ -946,7 +946,7 @@ func TestAccBuildingBlockDefinition(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, TouchesExclusively(client.MeshObjectKind.BuildingBlockDefinition))
 	})
 }
 

--- a/internal/provider/landingzone_resource_test.go
+++ b/internal/provider/landingzone_resource_test.go
@@ -70,7 +70,7 @@ func TestAccLandingZone(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, TouchesExclusively(client.MeshObjectKind.LandingZone))
 	})
 
 	t.Run("only_restricted_injected_no_declared_tags", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestAccLandingZone(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, TouchesExclusively(client.MeshObjectKind.LandingZone))
 	})
 
 	t.Run("declared_restricted_tag_kept", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestAccLandingZone(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, TouchesExclusively(client.MeshObjectKind.LandingZone))
 	})
 
 	config, landingZoneAddr := testconfig.LandingZoneAndWorkspace(t)

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -48,7 +48,7 @@ func TestAccProject(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, TouchesExclusively(client.MeshObjectKind.Project))
 	})
 
 	config, resourceAddress, workspaceAddr := testconfig.ProjectAndWorkspace(t)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3,9 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -73,14 +76,78 @@ provider "meshstack" {
 }
 `
 
+// restrictedTagLocks serialize the tests that create a restricted tag definition with a default
+// value. Such a definition is global to its meshObject kind: the backend adds the tag to every
+// resource of that kind, so a test running at the same time fails its empty-plan and import checks.
+// The random name suffix isolates the tag's key, not its effect.
+var restrictedTagLocks = map[string]*sync.RWMutex{
+	client.MeshObjectKind.BuildingBlockDefinition: {},
+	client.MeshObjectKind.LandingZone:             {},
+	client.MeshObjectKind.Project:                 {},
+}
+
+type ApplyAndTestOption func(*applyAndTestOptions)
+
+type applyAndTestOptions struct {
+	LockExclusiveKinds []string
+}
+
+// TouchesExclusively marks a test that creates a restricted tag definition with a default value for
+// the given kind. See restrictedTagLocks for why such a test cannot run next to others.
+func TouchesExclusively(kind string) ApplyAndTestOption {
+	return func(options *applyAndTestOptions) {
+		options.LockExclusiveKinds = append(options.LockExclusiveKinds, kind)
+	}
+}
+
+// acquireRestrictedTagLocks must run after t.Parallel() has returned. Until then the test is
+// paused, and a read lock taken earlier would make a writer wait for a test that has not started.
+func acquireRestrictedTagLocks(t *testing.T, options applyAndTestOptions) func() {
+	t.Helper()
+
+	slices.Sort(options.LockExclusiveKinds)
+
+	for _, kind := range options.LockExclusiveKinds {
+		if _, ok := restrictedTagLocks[kind]; !ok {
+			t.Fatalf("TouchesExclusively(%q): unknown meshObject kind, add it to restrictedTagLocks", kind)
+		}
+	}
+
+	releases := make([]func(), 0, len(restrictedTagLocks))
+	// Sorted, so every caller takes the locks in the same order. Ranging over the map directly
+	// would let writers of different kinds deadlock.
+	for _, kind := range slices.Sorted(maps.Keys(restrictedTagLocks)) {
+		lock := restrictedTagLocks[kind]
+		if slices.Contains(options.LockExclusiveKinds, kind) {
+			lock.Lock()
+			releases = append(releases, lock.Unlock)
+		} else {
+			lock.RLock()
+			releases = append(releases, lock.RUnlock)
+		}
+	}
+
+	return func() {
+		for _, release := range releases {
+			release()
+		}
+	}
+}
+
 // ApplyAndTest runs a TF test case. When TF_ACC is not set, it uses a mock
 // client (unit test mode). When TF_ACC is set, it runs against a real meshStack.
-// All tests using ApplyAndTest run in parallel.
+// All tests using ApplyAndTest run in parallel, except that a test marked with
+// TouchesExclusively runs alone.
 //
 // When MESHSTACK_SCRATCH_DUMP is set, it instead dumps each step's config to disk and
 // returns without running the test (see dumpStepConfigs).
-func ApplyAndTest(t *testing.T, testCase resource.TestCase) {
+func ApplyAndTest(t *testing.T, testCase resource.TestCase, opts ...ApplyAndTestOption) {
 	t.Helper()
+
+	var options applyAndTestOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 
 	if target := os.Getenv(envKeyScratchDump); target != "" {
 		dumpStepConfigs(t, target, testCase.Steps)
@@ -99,6 +166,8 @@ func ApplyAndTest(t *testing.T, testCase resource.TestCase) {
 		// os.Setenv (not t.Setenv) because t.Setenv is incompatible with the t.Parallel() call below.
 		require.NoError(t, os.Setenv("MESHSTACK_SKIP_VERSION_CHECK", "true")) //nolint:usetesting // see comment above
 		t.Parallel()
+		releaseRestrictedTagLocks := acquireRestrictedTagLocks(t, options)
+		defer releaseRestrictedTagLocks()
 		testCase.PreCheck = func() { DefaultTestPreCheck(t) }
 		testCase.ProtoV6ProviderFactories = ProviderFactoriesForTest()
 	}


### PR DESCRIPTION
## tf-acc-stability

This branch is part of a larger piece of work: a green acceptance run must mean that the suite ran and
passed. The companion work lives in meshcloud's private `meshfed-release` backend repo, whose
`terraform-provider-acceptance` CI job builds the backend from source and runs *this* repo's
acceptance suite against it. That job is being made trustworthy, properly cached and readable.
Trustworthy means that a green result only appears when the suite ran to the end. Cached means that
an unchanged tree is not tested twice. Readable means that a failure says what broke without anyone
reading four thousand log lines.

The Gradle build cache had always hidden a race in this repo's own acceptance suite. Running that
suite cold, without the cache, made tests fail because of that race. This PR fixes it.

### The race

A restricted tag definition with a **default value** applies to a whole meshObject kind, not only to
the test that created it. On create, the backend injects that default into every resource of that
kind, whether or not the caller declared the tag. `ApplyAndTest` calls `t.Parallel()` for every
acceptance test, so all `TestAcc` functions and their subtests run concurrently in one process. While
one of the five subtests that create such a definition runs, the backend injects the tag into every
resource of that kind that another test created at the same time.

Those other tests then fail in their import steps. The injected tag breaks **two** different
assertions. This is worth stating, because a grep for the no-op import message alone counts too few
failures:

```
Step 3/4 error running import: importing resource
meshstack_building_block_definition.example_05_gitlab_pipeline:
expected a no-op import operation, got ["update"] action with plan
  ~ tags = { - "test-key-87eaxid0" = [ - "injected-default" ] -> null }

Step 2/2 error running import: ImportStateVerify attributes not equivalent.
+ 	"metadata.tags.test-key-mmzgdunc.0": "injected-default",
```

Five subtests create such a definition, across three kinds:

| test | kind |
|---|---|
| `TestAccBuildingBlockDefinition/12_restricted_default_tag` | `meshBuildingBlockDefinition` |
| `TestAccLandingZone/restricted_default_tag` | `meshLandingZone` |
| `TestAccLandingZone/only_restricted_injected_no_declared_tags` | `meshLandingZone` |
| `TestAccLandingZone/declared_restricted_tag_kept` | `meshLandingZone` |
| `TestAccProject/restricted_default_tag` | `meshProject` |

Each of them runs in under 5 seconds, which is why the race is rare rather than constant.

**This is not a provider bug.** `reconcileTrackedTags` (`internal/provider/tags_reconcile.go`) removes
injected restricted defaults from the managed `tags` attribute on create and read. Its comment says
that import is different on purpose: on import there is no prior state, so the provider returns the
API's full tag set unchanged. The provider does exactly what it documents, and the failing test fails
only because another test made the backend inject a tag.

The race does break an invariant that the `acceptance-testing` skill states: "every test creates the
resources it needs with random-suffixed names, so runs never collide". A random suffix makes the tag's
**key** unique per test, but it does not limit the tag's **effect**, which applies to every object of
the kind.

### The fix

`ApplyAndTest` now takes three locks, one `sync.RWMutex` per affected kind. It takes them after
`t.Parallel()` returns. A test takes the write lock for each kind it declares through the new
`TouchesExclusively(kind)` option, and the read lock for the other kinds. While one of the five
writers runs, no other acceptance test runs, because every test needs a read lock on all three kinds.
The rest of the time, all tests run concurrently as before. Only `internal/provider` defines `TestAcc`
functions, so `go test ./...` runs them all as goroutines of a single process. An in-memory lock is
therefore enough, and no file lock is needed.

Deliberate details:

- **Every test takes all three read locks, and it does so inside `ApplyAndTest`.** No subtest can
  forget the locks this way, and nobody has to keep a table of type names up to date when someone adds
  a resource.
- **A test takes the locks only after `t.Parallel()` returns.** `t.Parallel()` pauses the test until
  the parallel phase begins. A test that took the read locks before that call would hold them for the
  whole time it is paused and doing no work, and a writer would then wait for tests that have not
  started yet.
- **Every test takes the locks in the same fixed key order.** Without a fixed order, two writers of
  different kinds could each hold one lock and wait for the other one, which is a deadlock.
  `TouchesExclusively` fails the test when it gets a kind that `restrictedTagLocks` does not know,
  instead of doing nothing quietly.
- **The locks apply in acceptance mode only.** `ApplyAndTest` does not call `t.Parallel()` for the
  mock client, so unit mode already runs sequentially and needs no lock.
- **The mechanism covers only restricted tag definitions that have a default value**, not all tag
  definitions. Covering all of them would add `meshWorkspace`, the builder the suite uses most, and
  eleven more barriers, against a hazard that we have reasoned about but never observed.

### Evidence

Measured on 2026-08-17 against a local meshStack. `TestAccBuildingBlockDefinition` is the workload that
shows the difference, because it keeps many building block definitions in place at the same time, so
the injected default has many resources it can break:

```sh
go test ./internal/provider/ -count=5 -timeout 60m -run 'TestAccBuildingBlockDefinition'
```

| | iterations failed | subtest runs failed |
|---|---|---|
| before the fix (`5d103fc`) | 5 of 5 | 10 of 85, every failure naming `injected-default` |
| after the fix (this branch) | 0 of 5 | 0 of 85 |

**Do not use the narrower two-subtest reproducer.** Running only `05_gitlab_pipeline` and
`12_restricted_default_tag` together looks like the tighter reproducer, but it is not: it failed 1 time
in 60, so as a regression guard it would pass on the broken code almost every time.

Cost: the full suite ran 229s without the fix and 220s with it. That is one sample per side, so read it
as "no measurable cost", not as a measurement. The barrier is real, but it is small compared to the
whole parallel workload. If it ever does cost real time, change the read side and narrow it to the
kinds a test's config mentions. Do not change the writer side.

There is no `CHANGELOG.md` entry, because a `test:` change is not user-facing (see the
`changelog-management` skill).

## Cross-repo PRs

- meshcloud/terraform-provider-meshstack#281 — this PR. It serializes the five acceptance subtests that
  create a restricted tag definition with a default value, so the backend can no longer inject a
  default into a resource that another test is using at the same time.
- meshcloud/meshfed-release#10653 *(meshcloud-internal, private repo)* — makes the
  `terraform-provider-acceptance` CI job trustworthy, cached and readable. It adds a completeness
  guard, so a run that the runner cut short can no longer be recorded as a pass. It fixes the Gradle
  cache key, so an unchanged tree is not tested again. It streams `gotestsum` output and adds a JUnit
  report and a job summary.

Both branches are named `feature/tf-acc-stability` on purpose. The "resolve
terraform-provider-meshstack branch" CI step in `meshfed-release` looks for a provider branch of the
same name and uses `main` when there is none. The identical name is what makes that job test the two
changes together. If you rename either branch, the pairing stops without any warning.
