### PR TITLE
feat: github platform type removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Requires meshStack 2026.32.0 or later (previously 2026.30.0).
 BREAKING CHANGES:
 - `meshstack_tenant` and `meshstack_tenants` now use the meshTenant v4 GA media type instead of the v4 preview media type. They require a meshStack backend that has promoted meshTenant v4 to GA; older backends that only serve the `-preview` media type return HTTP 415 (Unsupported Media Type).
 - The deprecated `meshstack_tenant_v4` resource and data source have been removed, along with the `moved` state mover that migrated from it (the source schema it was built from no longer exists). Migrate to `meshstack_tenant` / `meshstack_tenants` by adding a `moved` block on v0.24.x — which still ships both the mover and the deprecated type — and applying it before upgrading to v0.25.0.
+- `meshstack_platform_types`: the `category` filter no longer accepts `GITHUB`. meshStack retired the dedicated GitHub platform type, and the platforms that had it are now `CUSTOM`. Change any `category = "GITHUB"` filter to `category = "CUSTOM"`.
 
 # v0.24.4
 

--- a/docs/data-sources/platform_types.md
+++ b/docs/data-sources/platform_types.md
@@ -25,7 +25,7 @@ data "meshstack_platform_types" "all" {
 
 ### Optional
 
-- `category` (String) Filter platform types by category. Possible values: OPENSTACK, CLOUDFOUNDRY, SERVICEREGISTRY, AWS, OPENSHIFT, KUBERNETES, AZURE, GCP, AZURE_KUBERNETES_SERVICE, AZURE_RESOURCE_GROUP, CUSTOM, GITHUB.
+- `category` (String) Filter platform types by category. Possible values: OPENSTACK, CLOUDFOUNDRY, SERVICEREGISTRY, AWS, OPENSHIFT, KUBERNETES, AZURE, GCP, AZURE_KUBERNETES_SERVICE, AZURE_RESOURCE_GROUP, CUSTOM.
 - `lifecycle_status` (String) Filter platform types by lifecycle status
 
 ### Read-Only

--- a/internal/provider/platform_types_data_source.go
+++ b/internal/provider/platform_types_data_source.go
@@ -16,7 +16,7 @@ var platformTypeCategories = []string{
 	"OPENSTACK", "CLOUDFOUNDRY", "SERVICEREGISTRY", "AWS",
 	"OPENSHIFT", "KUBERNETES", "AZURE", "GCP",
 	"AZURE_KUBERNETES_SERVICE", "AZURE_RESOURCE_GROUP",
-	"CUSTOM", "GITHUB",
+	"CUSTOM",
 }
 
 func NewPlatformTypesDataSource() datasource.DataSource {


### PR DESCRIPTION
It's being merged into the custom type, as it was, essentially, treated like one.