### PR TITLE
fix: honor MESHSTACK_SKIP_VERSION_CHECK before requesting /mesh/info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ BREAKING CHANGES:
 - The deprecated `meshstack_tenant_v4` resource and data source have been removed, along with the `moved` state mover that migrated from it (the source schema it was built from no longer exists). Migrate to `meshstack_tenant` / `meshstack_tenants` by adding a `moved` block on v0.24.x — which still ships both the mover and the deprecated type — and applying it before upgrading to v0.25.0.
 - `meshstack_platform_types`: the `category` filter no longer accepts `GITHUB`. meshStack retired the dedicated GitHub platform type, and the platforms that had it are now `CUSTOM`. Change any `category = "GITHUB"` filter to `category = "CUSTOM"`.
 
+FIXES:
+- `MESHSTACK_SKIP_VERSION_CHECK=true` now skips the `GET /mesh/info` version-check request itself, instead of only suppressing the resulting version mismatch. Previously the opt-out was evaluated after the request had succeeded, so an unavailable meshStack still failed provider configuration — after blocking for the client's full retry budget (~4 minutes), because `/mesh/info` is a retried GET.
+
 # v0.24.4
 
 BREAKING CHANGES:

--- a/client/client.go
+++ b/client/client.go
@@ -99,6 +99,13 @@ func New(ctx context.Context, rootUrl *url.URL, userAgent string, auth Authoriza
 }
 
 func checkMeshVersion(ctx context.Context, httpClient internal.HttpClient) error {
+	// Skip before the request, not just before the comparison: /mesh/info is a GET on the retrying
+	// client, so an unavailable backend blocks provider configuration for the whole retry budget
+	// (~4 minutes) and then fails it. Opting out of the check has to opt out of that too.
+	if os.Getenv("MESHSTACK_SKIP_VERSION_CHECK") == "true" {
+		return nil
+	}
+
 	type MeshInfo struct {
 		Version version.Version `json:"version"`
 	}
@@ -107,9 +114,6 @@ func checkMeshVersion(ctx context.Context, httpClient internal.HttpClient) error
 	if meshInfo, err := internal.DoRequest[MeshInfo](ctx, httpClient, "GET", meshInfoEndpoint); err != nil {
 		return fmt.Errorf("failed to retrieve meshStack version information from %s endpoint: %w", meshInfoEndpoint, err)
 	} else if meshInfo.Version.Less(MinMeshStackVersion) {
-		if os.Getenv("MESHSTACK_SKIP_VERSION_CHECK") == "true" {
-			return nil
-		}
 		return fmt.Errorf("unsupported meshStack version: meshStack is running version %s, but this client requires version %s or higher", meshInfo.Version, MinMeshStackVersion)
 	}
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meshcloud/terraform-provider-meshstack/client/internal"
+)
+
+type erroringRoundTripper struct{ calls int }
+
+func (rt *erroringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	rt.calls++
+	return nil, errors.New("no server is available to handle this request")
+}
+
+func TestCheckMeshVersion_SkipsRequestWhenOptedOut(t *testing.T) {
+	newUnreachableClient := func() (internal.HttpClient, *erroringRoundTripper) {
+		transport := new(erroringRoundTripper)
+		httpClient := internal.NewHttpClient(&url.URL{Scheme: "https", Host: "meshstack.invalid"}, "test-agent", nil)
+		httpClient.Transport = transport
+		return httpClient, transport
+	}
+
+	t.Run("MESHSTACK_SKIP_VERSION_CHECK=true skips the /mesh/info request entirely", func(t *testing.T) {
+		t.Setenv("MESHSTACK_SKIP_VERSION_CHECK", "true")
+		httpClient, transport := newUnreachableClient()
+		require.NoError(t, checkMeshVersion(t.Context(), httpClient))
+		assert.Zero(t, transport.calls, "opting out of the version check must not send a request that can block on retries")
+	})
+
+	t.Run("without the opt-out an unreachable /mesh/info fails", func(t *testing.T) {
+		t.Setenv("MESHSTACK_SKIP_VERSION_CHECK", "")
+		httpClient, transport := newUnreachableClient()
+		err := checkMeshVersion(t.Context(), httpClient)
+		require.ErrorContains(t, err, "failed to retrieve meshStack version information")
+		assert.Equal(t, 1, transport.calls)
+	})
+}


### PR DESCRIPTION
## The bug

In `checkMeshVersion` (`client/client.go`), the `MESHSTACK_SKIP_VERSION_CHECK == "true"` check sat
*inside* the `else if` branch that handles a version mismatch, so it was only reachable once
`GET /mesh/info` had already succeeded. Setting the flag therefore never skipped the request — it
only suppressed a version *mismatch*.

## The fix

Move the env check to the top of `checkMeshVersion`, so the flag short-circuits before the request is
built.

## Why it matters

`/mesh/info` is a `GET` issued on the *retrying* client (`client.New` wraps the HTTP client in
`internal.WithRetry` before calling `checkMeshVersion`, and `retryRoundTripper` retries all
idempotent methods, backing off on 503). So with the flag set, an unavailable meshStack did not fail
fast: every provider configure blocked for the client's full retry budget — `MaxRetries: 12` with the
`1+2+4+8+16+30*7` s backoff sequence, ~4 minutes — and then returned a hard error anyway, with no way
to opt out.

That is what the meshStack smoke tests hit: they set `MESHSTACK_SKIP_VERSION_CHECK=true` precisely to
decouple CI from this check, and it did not work. A dev-environment 503 window longer than the retry
budget (observed: 4–12 min) failed provider configuration for the entire test matrix at `init` time,
including in the destroy phase of tests that had already passed — leaving objects behind.

## Test

`client/client_test.go` covers both directions against a stub transport that always errors: with the
flag set, `checkMeshVersion` succeeds and the transport is never called at all; with the flag unset,
the request error surfaces. Verified to fail on the pre-fix code.

## Open question

Should a `/mesh/info` transport error be fatal at all, or a warning — a version *check* failing is
not the same as the API being unusable, and every subsequent call has its own retry/error handling?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
