### PR TITLE
feat: support adopting an existing identity provider on entra id integrations

### DIFF
--- a/.agents/skills/resource-development/SKILL.md
+++ b/.agents/skills/resource-development/SKILL.md
@@ -76,6 +76,16 @@ fields. Only refs mixing name *and* uuid (`MeshBuildingBlockV2TargetRef`) stay b
 
 Cross-cutting rules for the schema and its backing client, beyond the ref/DTO shape above:
 
+- **A computed value never sits inside a container configuration writes.** `metadata` and `spec` hold
+  inputs only; system-managed values belong top-level or in a fully computed container (`status`,
+  `ref`, `version_latest`). The reason is testability, not tidiness: OpenTofu's mock value generator
+  copies a config-written container verbatim and never descends into it, so a computed leaf under
+  `metadata`/`spec` is null under `mock_provider` and cannot be given a value by `override_*` either
+  — which makes any module wiring that reads it impossible to unit test. Depth is irrelevant; the
+  config-written ancestor is the only thing that disqualifies the subtree, and `Optional`+`Computed`
+  does not rescue it. When the API returns such a value inside `spec`, keep the client field
+  (`tfsdk:"-"`) and expose it from `status` via a local model struct — see the computed-only output
+  field pattern in `REFERENCE.md`. Tracked in #272.
 - **Naming — `Id`/`Uuid`, never `ID`/`UUID`.** For any acronym of 2+ letters only the first letter
   is uppercase (`TenantId`, `ProjectUuid`) — it keeps mixed identifiers like `apiKeyId` readable.
 - **Value receivers for client structs.** All client implementation and mock structs use value
@@ -149,6 +159,9 @@ fields plus the derived field — do **not** modify client types or call `SetAtt
 
 ## Conventions worth flagging in review
 
+- **Any new `Computed` attribute: is an ancestor written by configuration?** If yes, it belongs in
+  `status` (or another fully computed container) instead — see the schema conventions above. This is
+  answerable from the schema diff alone, so it is worth checking on every review.
 - **Response-only pointer fields are never nil in responses.** Client DTO structs are reused for
   both requests and responses, so system-managed, response-only fields (e.g. a `Status *...`) are
   pointers *only* so they can be omitted from request payloads. On a GET the backend always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.25.1
+
+Requires meshStack 2026.35.0 or later (previously 2026.34.0).
+
+FEATURES:
+- `meshstack_integration`: new `spec.config.entraid.idp_alias` argument adopts an identity provider that already exists in your meshStack, instead of having meshStack create one. Leave it out and meshStack generates an alias. The alias cannot be changed afterwards, and a plan that changes it fails. `meshstack_integrations` exposes it too.
+
 # v0.25.0
 
 Requires meshStack 2026.34.0 or later (previously 2026.30.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Requires meshStack 2026.35.0 or later (previously 2026.34.0).
 
+BREAKING CHANGES:
+- `meshstack_integration` and `meshstack_integrations`: the Entra ID redirect URL moved from `spec.config.entraid.redirect_url` to `status.entraid.redirect_url`. meshStack derives it, so it belongs in the computed `status` container rather than in `spec`, which configuration writes (#272). Setting it never worked anyway — meshStack ignored the value and the apply failed on the inconsistency.
+
 FEATURES:
 - `meshstack_integration`: new `spec.config.entraid.idp_alias` argument adopts an identity provider that already exists in your meshStack, instead of having meshStack create one. Leave it out and meshStack generates an alias. The alias cannot be changed afterwards, and a plan that changes it fails. `meshstack_integrations` exposes it too.
 

--- a/client/client.go
+++ b/client/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/meshcloud/terraform-provider-meshstack/client/version"
 )
 
-var MinMeshStackVersion = version.MustParse("2026.34.0")
+var MinMeshStackVersion = version.MustParse("2026.35.0")
 
 // HttpError represents an HTTP error response with status code.
 // This error is returned when an HTTP request fails with a non-2XX status code.

--- a/client/integration_config.go
+++ b/client/integration_config.go
@@ -43,6 +43,7 @@ type MeshIntegrationEntraIdConfig struct {
 	TenantId     string       `json:"tenantId" tfsdk:"tenant_id"`
 	ClientId     string       `json:"clientId" tfsdk:"client_id"`
 	ClientSecret types.Secret `json:"clientSecret" tfsdk:"client_secret"`
+	IdpAlias     *string      `json:"idpAlias,omitempty" tfsdk:"idp_alias"`
 	RedirectUrl  *string      `json:"redirectUrl,omitempty" tfsdk:"redirect_url"`
 }
 

--- a/client/integration_config.go
+++ b/client/integration_config.go
@@ -44,7 +44,9 @@ type MeshIntegrationEntraIdConfig struct {
 	ClientId     string       `json:"clientId" tfsdk:"client_id"`
 	ClientSecret types.Secret `json:"clientSecret" tfsdk:"client_secret"`
 	IdpAlias     *string      `json:"idpAlias,omitempty" tfsdk:"idp_alias"`
-	RedirectUrl  *string      `json:"redirectUrl,omitempty" tfsdk:"redirect_url"`
+	// meshStack derives this and returns it inside spec, which configuration writes. A computed value
+	// there is unreachable under provider mocks (issue #272), so Terraform reads it from status instead.
+	RedirectUrl *string `json:"redirectUrl,omitempty" tfsdk:"-"`
 }
 
 type MeshIntegrationConfig struct {

--- a/docs/data-sources/integrations.md
+++ b/docs/data-sources/integrations.md
@@ -150,6 +150,7 @@ Read-Only:
 
 - `client_id` (String) Entra ID application (client) ID.
 - `client_secret` (Attributes) (see [below for nested schema](#nestedatt--integrations--spec--config--entraid--client_secret))
+- `idp_alias` (String) Alias of the identity provider backing this integration.
 - `tenant_id` (String) Entra ID tenant ID.
 
 <a id="nestedatt--integrations--spec--config--entraid--client_secret"></a>

--- a/docs/data-sources/integrations.md
+++ b/docs/data-sources/integrations.md
@@ -43,8 +43,17 @@ Read-Only:
 
 Read-Only:
 
+- `entraid` (Attributes) Derived state of an Entra ID integration. (see [below for nested schema](#nestedatt--integrations--status--entraid))
 - `is_built_in` (Boolean) Indicates whether this is a built-in integration (replicator or metering).
 - `workload_identity_federation` (Attributes) (see [below for nested schema](#nestedatt--integrations--status--workload_identity_federation))
+
+<a id="nestedatt--integrations--status--entraid"></a>
+### Nested Schema for `integrations.status.entraid`
+
+Read-Only:
+
+- `redirect_url` (String) OAuth2 redirect URL, which meshStack derives from `idp_alias`.
+
 
 <a id="nestedatt--integrations--status--workload_identity_federation"></a>
 ### Nested Schema for `integrations.status.workload_identity_federation`
@@ -141,10 +150,6 @@ Read-Only:
 
 <a id="nestedatt--integrations--spec--config--entraid"></a>
 ### Nested Schema for `integrations.spec.config.entraid`
-
-Optional:
-
-- `redirect_url` (String) OAuth2 redirect URL. Computed by meshStack.
 
 Read-Only:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: |-
 
 The meshStack terraform provider is an open-source tool, licensed under the MPL-2.0, and is actively maintained by meshcloud GmbH. The provider exposes APIs of meshStack to manage resources as code.
 
-**Note:** This provider version requires meshStack version 2026.34.0 or higher. The provider automatically validates version compatibility during initialization.
+**Note:** This provider version requires meshStack version 2026.35.0 or higher. The provider automatically validates version compatibility during initialization.
 
 ## Dependency wiring patterns
 

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -186,6 +186,7 @@ Required:
 
 Optional:
 
+- `idp_alias` (String) Alias of the identity provider backing this integration. Set it to adopt an identity provider that already exists in your meshStack; leave it out and meshStack generates an alias. It cannot be changed afterwards.
 - `redirect_url` (String) OAuth2 redirect URL. Computed by meshStack.
 
 <a id="nestedatt--spec--config--entraid--client_secret"></a>

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -187,7 +187,6 @@ Required:
 Optional:
 
 - `idp_alias` (String) Alias of the identity provider backing this integration. Set it to adopt an identity provider that already exists in your meshStack; leave it out and meshStack generates an alias. It cannot be changed afterwards.
-- `redirect_url` (String) OAuth2 redirect URL. Computed by meshStack.
 
 <a id="nestedatt--spec--config--entraid--client_secret"></a>
 ### Nested Schema for `spec.config.entraid.client_secret`
@@ -283,8 +282,17 @@ Read-Only:
 
 Read-Only:
 
+- `entraid` (Attributes) Derived state of an Entra ID integration. Null for other integration types. (see [below for nested schema](#nestedatt--status--entraid))
 - `is_built_in` (Boolean) For integrations created by this resource, this flag is always `false`
 - `workload_identity_federation` (Attributes) Workload identity federation configuration for the integration. (see [below for nested schema](#nestedatt--status--workload_identity_federation))
+
+<a id="nestedatt--status--entraid"></a>
+### Nested Schema for `status.entraid`
+
+Read-Only:
+
+- `redirect_url` (String) OAuth2 redirect URL, which meshStack derives from `idp_alias`. Register it in your Entra ID app registration.
+
 
 <a id="nestedatt--status--workload_identity_federation"></a>
 ### Nested Schema for `status.workload_identity_federation`

--- a/internal/clientmock/mock_integration.go
+++ b/internal/clientmock/mock_integration.go
@@ -26,8 +26,13 @@ func (m MeshIntegrationClient) Create(_ context.Context, integration client.Mesh
 		},
 	}
 	backendSecretBehavior(true, created, nil)
-	if created.Spec.Config.EntraId != nil && created.Spec.Config.EntraId.RedirectUrl == nil {
-		created.Spec.Config.EntraId.RedirectUrl = new(fmt.Sprintf("https://meshstack.example.com/oauth/redirect/%s", integrationUuid))
+	if created.Spec.Config.EntraId != nil {
+		if created.Spec.Config.EntraId.IdpAlias == nil {
+			created.Spec.Config.EntraId.IdpAlias = new(fmt.Sprintf("idp-integration-%s", integrationUuid))
+		}
+		if created.Spec.Config.EntraId.RedirectUrl == nil {
+			created.Spec.Config.EntraId.RedirectUrl = new(fmt.Sprintf("https://meshstack.example.com/oauth/redirect/%s", *created.Spec.Config.EntraId.IdpAlias))
+		}
 	}
 	m.Store.Set(integrationUuid, created)
 	return created, nil
@@ -43,9 +48,12 @@ func (m MeshIntegrationClient) Read(_ context.Context, uuid string) (*client.Mes
 func (m MeshIntegrationClient) Update(_ context.Context, integration client.MeshIntegration) (*client.MeshIntegration, error) {
 	if existing, ok := m.Store.Get(*integration.Metadata.Uuid); ok {
 		backendSecretBehavior(false, &integration, existing)
-		if integration.Spec.Config.EntraId != nil && integration.Spec.Config.EntraId.RedirectUrl == nil &&
-			existing.Spec.Config.EntraId != nil {
-			integration.Spec.Config.EntraId.RedirectUrl = existing.Spec.Config.EntraId.RedirectUrl
+		if integration.Spec.Config.EntraId != nil && existing.Spec.Config.EntraId != nil {
+			// The alias is immutable: the backend ignores whatever the request carries.
+			integration.Spec.Config.EntraId.IdpAlias = existing.Spec.Config.EntraId.IdpAlias
+			if integration.Spec.Config.EntraId.RedirectUrl == nil {
+				integration.Spec.Config.EntraId.RedirectUrl = existing.Spec.Config.EntraId.RedirectUrl
+			}
 		}
 		existing.Spec = integration.Spec
 		return existing, nil

--- a/internal/modifiers/integrationmodifier/idp_alias_immutable.go
+++ b/internal/modifiers/integrationmodifier/idp_alias_immutable.go
@@ -1,0 +1,65 @@
+package integrationmodifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// idpAliasImmutableModifier rejects a change to an Entra ID integration's identity provider alias.
+//
+// meshStack cannot repoint an integration at another identity provider, so the only way to express the
+// change would be a destroy and recreate. Deleting the integration deletes the identity provider that
+// carries the alias, which for an adopted alias is one the customer configured themselves — too much to
+// do for an edited string. Reject the change instead, the way version_spec does in
+// building_block_definition_resource.go. The framework ships no equivalent: stringplanmodifier offers
+// only RequiresReplace variants and UseStateForUnknown, and a validator cannot see prior state.
+type idpAliasImmutableModifier struct{}
+
+func (m idpAliasImmutableModifier) Description(ctx context.Context) string {
+	return "Rejects a change to the identity provider alias"
+}
+
+func (m idpAliasImmutableModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m idpAliasImmutableModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Not applicable on create (no prior state) or destroy (no plan), nor when the configuration leaves
+	// the alias to meshStack.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() || req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if req.ConfigValue.Equal(req.StateValue) {
+		return
+	}
+
+	// State written before the alias existed, or a plan run with -refresh=false, leaves it unknown to
+	// Terraform. Refuse either way: letting the request go out only moves the failure past the apply.
+	if req.StateValue.IsNull() {
+		resp.Diagnostics.AddAttributeError(req.Path, "Error updating idp_alias", fmt.Sprintf(
+			"The identity provider alias of an Entra ID integration cannot be changed, and Terraform does "+
+				"not know the current one, so it cannot tell whether %q is a change. Refresh the state and "+
+				"try again.",
+			req.ConfigValue.ValueString(),
+		))
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(req.Path, "Error updating idp_alias", fmt.Sprintf(
+		"The identity provider alias of an Entra ID integration cannot be changed. It is %q and the "+
+			"configuration asks for %q. Applying that would delete identity provider %q, which meshStack "+
+			"may not have created. Restore the current value, or remove this resource from state and "+
+			"import the integration that already uses %q.",
+		req.StateValue.ValueString(), req.ConfigValue.ValueString(),
+		req.StateValue.ValueString(), req.ConfigValue.ValueString(),
+	))
+}
+
+// IdpAliasImmutable rejects a change to an Entra ID integration's identity provider alias.
+func IdpAliasImmutable() planmodifier.String {
+	return idpAliasImmutableModifier{}
+}
+
+var _ planmodifier.String = idpAliasImmutableModifier{}

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -38,9 +38,37 @@ func (r *integrationResource) Configure(_ context.Context, req resource.Configur
 	})...)
 }
 
+// integrationStatus mirrors client.MeshIntegrationStatus and adds the Entra ID redirect URL, which
+// meshStack returns inside spec. A computed value under configuration-written spec cannot be reached or
+// set in provider mocks (issue #272), so Terraform exposes it from the computed status container instead.
+type integrationStatus struct {
+	EntraId                    *integrationStatusEntraId              `tfsdk:"entraid"`
+	IsBuiltIn                  bool                                   `tfsdk:"is_built_in"`
+	WorkloadIdentityFederation *client.MeshWorkloadIdentityFederation `tfsdk:"workload_identity_federation"`
+}
+
+// Nested per integration type, the way status.workload_identity_federation nests per cloud, so further
+// derived Entra ID values have somewhere to go.
+type integrationStatusEntraId struct {
+	RedirectUrl *string `tfsdk:"redirect_url"`
+}
+
+func integrationStatusFromDto(dto *client.MeshIntegration) *integrationStatus {
+	status := integrationStatus{
+		IsBuiltIn:                  dto.Status.IsBuiltIn,
+		WorkloadIdentityFederation: dto.Status.WorkloadIdentityFederation,
+	}
+	if dto.Spec.Config.EntraId != nil {
+		status.EntraId = &integrationStatusEntraId{RedirectUrl: dto.Spec.Config.EntraId.RedirectUrl}
+	}
+	return &status
+}
+
 type integrationModel struct {
-	client.MeshIntegration
-	Ref struct {
+	Metadata client.MeshIntegrationMetadata `tfsdk:"metadata"`
+	Spec     client.MeshIntegrationSpec     `tfsdk:"spec"`
+	Status   *integrationStatus             `tfsdk:"status"`
+	Ref      struct {
 		Kind string `tfsdk:"kind"`
 		Uuid string `tfsdk:"uuid"`
 	} `tfsdk:"ref"`
@@ -63,11 +91,13 @@ func (model integrationModel) ToClientDto() client.MeshIntegration {
 	case client.MeshIntegrationConfigTypeAzureDevops:
 		setRunnerRefIfNil(&model.Spec.Config.AzureDevops.RunnerRef)
 	}
-	return model.MeshIntegration
+	return client.MeshIntegration{Metadata: model.Metadata, Spec: model.Spec}
 }
 
 func (model *integrationModel) SetFromClientDto(dto *client.MeshIntegration) {
-	model.MeshIntegration = *dto
+	model.Metadata = dto.Metadata
+	model.Spec = dto.Spec
+	model.Status = integrationStatusFromDto(dto)
 	model.Ref.Kind = client.MeshObjectKind.Integration
 	model.Ref.Uuid = *dto.Metadata.Uuid
 }
@@ -126,7 +156,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError("Error updating meshIntegration", fmt.Sprintf("Updating integration '%s' failed: %s", *plan.Metadata.Uuid, err.Error()))
 		return
 	}
-	plan.MeshIntegration = *updatedDto
+	plan.SetFromClientDto(updatedDto)
 	resp.Diagnostics.Append(generic.Set(ctx, &resp.State, plan, secret.WithConverterSupport(ctx, req.Config, req.Plan, nil)...)...)
 }
 

--- a/internal/provider/integration_resource_schema.go
+++ b/internal/provider/integration_resource_schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
+	"github.com/meshcloud/terraform-provider-meshstack/internal/modifiers/integrationmodifier"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/secret"
 )
 
@@ -182,6 +183,17 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 										MarkdownDescription: "Client secret for the Entra ID application.",
 										Optional:            false,
 									}),
+									"idp_alias": schema.StringAttribute{
+										MarkdownDescription: "Alias of the identity provider backing this integration. Set it to adopt an " +
+											"identity provider that already exists in your meshStack; leave it out and meshStack generates an alias. " +
+											"It cannot be changed afterwards.",
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.String{
+											integrationmodifier.IdpAliasImmutable(),
+											stringplanmodifier.UseNonNullStateForUnknown(),
+										},
+									},
 									"redirect_url": schema.StringAttribute{
 										MarkdownDescription: "OAuth2 redirect URL. Computed by meshStack.",
 										Optional:            true,

--- a/internal/provider/integration_resource_schema.go
+++ b/internal/provider/integration_resource_schema.go
@@ -194,11 +194,6 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 											stringplanmodifier.UseNonNullStateForUnknown(),
 										},
 									},
-									"redirect_url": schema.StringAttribute{
-										MarkdownDescription: "OAuth2 redirect URL. Computed by meshStack.",
-										Optional:            true,
-										Computed:            true,
-									},
 								},
 							},
 						},
@@ -209,6 +204,17 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 				MarkdownDescription: "Status information of the integration. System-managed state computed by meshStack.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
+					"entraid": schema.SingleNestedAttribute{
+						MarkdownDescription: "Derived state of an Entra ID integration. Null for other integration types.",
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"redirect_url": schema.StringAttribute{
+								MarkdownDescription: "OAuth2 redirect URL, which meshStack derives from `idp_alias`. " +
+									"Register it in your Entra ID app registration.",
+								Computed: true,
+							},
+						},
+					},
 					"is_built_in": schema.BoolAttribute{
 						MarkdownDescription: "For integrations created by this resource, this flag is always `false`",
 						Computed:            true,

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -61,7 +61,7 @@ func TestAccIntegrationResource(t *testing.T) {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata"), checkIntegrationMetadata()),
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("01_github", "GitHub Integration")),
-						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus()),
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus(knownvalue.Null())),
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
@@ -105,7 +105,7 @@ func TestAccIntegrationResource(t *testing.T) {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata"), checkIntegrationMetadata()),
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("02_azure_devops", "Azure DevOps Integration")),
-						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus()),
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus(knownvalue.Null())),
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
@@ -139,7 +139,7 @@ func TestAccIntegrationResource(t *testing.T) {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata"), checkIntegrationMetadata()),
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("02_azure_devops", "Azure DevOps Integration")),
-						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus()),
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus(knownvalue.Null())),
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
@@ -182,7 +182,7 @@ func TestAccIntegrationResource(t *testing.T) {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata"), checkIntegrationMetadata()),
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("03_gitlab", "GitLab Integration")),
-						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus()),
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus(knownvalue.Null())),
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
@@ -232,7 +232,9 @@ func TestAccIntegrationResource(t *testing.T) {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("metadata"), checkIntegrationMetadata()),
 						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("04_entra_id", "Entra ID Integration")),
-						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus()),
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("status"), checkIntegrationStatus(xknownvalue.MapExact(map[string]knownvalue.Check{
+							"redirect_url": xknownvalue.NotEmptyString(),
+						}))),
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
@@ -402,8 +404,7 @@ func checkIntegrationConfig(exampleSuffix string) knownvalue.Check {
 					"secret_hash":    xknownvalue.NotEmptyString(),
 					"secret_version": xknownvalue.NotEmptyString(),
 				}),
-				"idp_alias":    xknownvalue.NotEmptyString(),
-				"redirect_url": xknownvalue.NotEmptyString(),
+				"idp_alias": xknownvalue.NotEmptyString(),
 			}),
 		})
 	default:
@@ -411,8 +412,9 @@ func checkIntegrationConfig(exampleSuffix string) knownvalue.Check {
 	}
 }
 
-func checkIntegrationStatus() knownvalue.Check {
+func checkIntegrationStatus(entraId knownvalue.Check) knownvalue.Check {
 	return xknownvalue.MapExact(map[string]knownvalue.Check{
+		"entraid":                      entraId,
 		"is_built_in":                  knownvalue.Bool(false),
 		"workload_identity_federation": knownvalue.Null(),
 	})

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -28,6 +29,17 @@ func updateIntegrationDisplayName(t *testing.T, config testconfig.Config, origin
 	updatedName := strings.Replace(originalName, "Integration", "Updated Integration", 1)
 	return config.WithFirstBlock(
 		testconfig.Descend("spec", "display_name")(testconfig.SetString(updatedName))).String()
+}
+
+// A factory for the same reason as azureDevopsPatPath.
+func entraIdClientSecretPath() tfjsonpath.Path {
+	return tfjsonpath.New("spec").AtMapKey("config").AtMapKey("entraid").AtMapKey("client_secret")
+}
+
+func adoptIdentityProvider(t *testing.T, config testconfig.Config, idpAlias string) string {
+	t.Helper()
+	return config.WithFirstBlock(
+		testconfig.Descend("spec", "config", "entraid", "idp_alias")(testconfig.SetString(idpAlias))).String()
 }
 
 func TestAccIntegrationResource(t *testing.T) {
@@ -203,6 +215,10 @@ func TestAccIntegrationResource(t *testing.T) {
 		// the pre-seeded AdminWorkspaceIdentifier instead of a freshly created test workspace.
 		config, resourceAddress := testconfig.IntegrationForWorkspace(t, "_04_entra_id", AdminWorkspaceIdentifier)
 		var resourceUuid string
+		rotatedSecretConfig := config.WithFirstBlock(
+			testconfig.Descend("spec", "config", "entraid", "client_secret")(
+				testconfig.SetRawExpr(`provider::meshstack::non_ephemeral_secret("updated-plaintext-secret")`),
+			)).String()
 
 		ApplyAndTest(t, resource.TestCase{
 			Steps: []resource.TestStep{
@@ -232,17 +248,77 @@ func TestAccIntegrationResource(t *testing.T) {
 						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
 					},
 				},
+				// Applying this would delete the identity provider the integration points at, so the plan
+				// has to fail rather than destroy and recreate.
+				{
+					Config:      adoptIdentityProvider(t, config, "adopted-idp-alias"),
+					ExpectError: regexp.MustCompile(`identity provider alias of an Entra ID integration cannot be changed`),
+				},
+				// A different value gives a different secret_version hash, which rotates secret_value.
+				{
+					Config: rotatedSecretConfig,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(resourceAddress.String(), plancheck.ResourceActionUpdate),
+							plancheck.ExpectKnownValue(resourceAddress.String(), entraIdClientSecretPath().AtMapKey("secret_version"), knownvalue.StringExact("b889814ec3c1da42df5abf57be4e989de7411b326ba30050fea6366185c0e206")),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceAddress.String(), tfjsonpath.New("spec"), checkIntegrationSpec("04_entra_id", "Entra ID Integration")),
+						xknownvalue.Ref(resourceAddress, "meshIntegration", &resourceUuid),
+					},
+				},
+				// On import the config wants secret_version as the value's sha256, but the backend returns
+				// its own hash, so the first plan sends the secret again. Same as 02_azure_devops.
 				{
 					ImportState:     true,
 					ImportStateKind: resource.ImportBlockWithID,
 					ImportStateIdFunc: func(state *terraform.State) (string, error) {
 						return resourceUuid, nil
 					},
-					ResourceName: resourceAddress.String(),
+					ResourceName:       resourceAddress.String(),
+					ExpectNonEmptyPlan: true,
+					ImportPlanChecks: resource.ImportPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(resourceAddress.String(), plancheck.ResourceActionUpdate),
+							plancheck.ExpectUnknownValue(resourceAddress.String(), entraIdClientSecretPath().AtMapKey("secret_hash")),
+						},
+					},
 				},
 			},
 		})
 	})
+
+	// Mock-only: adopting a fixed alias twice would collide on the real backend, which rejects an alias
+	// another Entra ID integration already uses.
+	t.Run("05_entra_id_adopt_mock_only", func(t *testing.T) {
+		if !IsMockClientTest() {
+			t.Skip("mock-only test: a fixed idp_alias cannot be re-adopted across runs on a real meshStack")
+		}
+
+		config, resourceAddress := testconfig.IntegrationForWorkspace(t, "_04_entra_id", AdminWorkspaceIdentifier)
+
+		ApplyAndTest(t, resource.TestCase{
+			Steps: []resource.TestStep{
+				// Creating with an alias adopts it rather than having meshStack generate one.
+				{
+					Config: adoptIdentityProvider(t, config, "pre-existing-idp"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceAddress.String(), entraIdIdpAliasPath(), knownvalue.StringExact("pre-existing-idp")),
+					},
+				},
+				// Dropping it from the configuration keeps the adopted alias, so the plan is empty.
+				{
+					Config:   config.String(),
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+}
+
+func entraIdIdpAliasPath() tfjsonpath.Path {
+	return tfjsonpath.New("spec").AtMapKey("config").AtMapKey("entraid").AtMapKey("idp_alias")
 }
 
 func checkIntegrationMetadata() knownvalue.Check {

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -326,6 +326,7 @@ func checkIntegrationConfig(exampleSuffix string) knownvalue.Check {
 					"secret_hash":    xknownvalue.NotEmptyString(),
 					"secret_version": xknownvalue.NotEmptyString(),
 				}),
+				"idp_alias":    xknownvalue.NotEmptyString(),
 				"redirect_url": xknownvalue.NotEmptyString(),
 			}),
 		})

--- a/internal/provider/integrations_data_source.go
+++ b/internal/provider/integrations_data_source.go
@@ -184,6 +184,10 @@ func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 													Computed:            true,
 												},
 												"client_secret": secret.DatasourceSchema(secret.DatasourceSchemaOptions{}),
+												"idp_alias": schema.StringAttribute{
+													MarkdownDescription: "Alias of the identity provider backing this integration.",
+													Computed:            true,
+												},
 												"redirect_url": schema.StringAttribute{
 													MarkdownDescription: "OAuth2 redirect URL. Computed by meshStack.",
 													Computed:            true,

--- a/internal/provider/integrations_data_source.go
+++ b/internal/provider/integrations_data_source.go
@@ -23,6 +23,14 @@ func NewIntegrationsDataSource() datasource.DataSource {
 	return &integrationsDataSource{}
 }
 
+// integrationsDataSourceItem shares integrationStatus with the resource, so the relocated redirect URL
+// has one derivation for both.
+type integrationsDataSourceItem struct {
+	Metadata client.MeshIntegrationMetadata `tfsdk:"metadata"`
+	Spec     client.MeshIntegrationSpec     `tfsdk:"spec"`
+	Status   *integrationStatus             `tfsdk:"status"`
+}
+
 // integrationsDataSource is the data source implementation.
 type integrationsDataSource struct {
 	meshIntegrationClient client.MeshIntegrationClient
@@ -188,11 +196,6 @@ func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 													MarkdownDescription: "Alias of the identity provider backing this integration.",
 													Computed:            true,
 												},
-												"redirect_url": schema.StringAttribute{
-													MarkdownDescription: "OAuth2 redirect URL. Computed by meshStack.",
-													Computed:            true,
-													Optional:            true,
-												},
 											},
 										},
 									},
@@ -204,6 +207,16 @@ func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 							Computed:            true,
 							Optional:            true,
 							Attributes: map[string]schema.Attribute{
+								"entraid": schema.SingleNestedAttribute{
+									MarkdownDescription: "Derived state of an Entra ID integration.",
+									Computed:            true,
+									Attributes: map[string]schema.Attribute{
+										"redirect_url": schema.StringAttribute{
+											MarkdownDescription: "OAuth2 redirect URL, which meshStack derives from `idp_alias`.",
+											Computed:            true,
+										},
+									},
+								},
 								"is_built_in": schema.BoolAttribute{
 									MarkdownDescription: "Indicates whether this is a built-in integration (replicator or metering).",
 									Computed:            true,
@@ -244,7 +257,15 @@ func (d *integrationsDataSource) Read(ctx context.Context, req datasource.ReadRe
 			}
 		}
 	}
-	integrations, err := generic.ValueFrom(integrationDtos, secret.WithDatasourceConverter())
+	items := make([]integrationsDataSourceItem, 0, len(integrationDtos))
+	for i := range integrationDtos {
+		items = append(items, integrationsDataSourceItem{
+			Metadata: integrationDtos[i].Metadata,
+			Spec:     integrationDtos[i].Spec,
+			Status:   integrationStatusFromDto(&integrationDtos[i]),
+		})
+	}
+	integrations, err := generic.ValueFrom(items, secret.WithDatasourceConverter())
 	if err != nil {
 		resp.Diagnostics.AddError("Value conversion error", err.Error())
 		return


### PR DESCRIPTION
## What this does

`meshstack_integration` gains `spec.config.entraid.idp_alias`. Set it to adopt an identity provider that already exists in a meshStack instance — typically one configured by hand — instead of having meshStack create one. Leave it out and meshStack generates an alias and reports it back. `meshstack_integrations` exposes it too.

The alias existed only in the internal API and the panel until now, so an existing identity provider could not be brought under Terraform management.

It also moves the Entra ID redirect URL into `status`, and adds the acceptance steps the Entra ID subtest was missing.

## Reading order

1. **`feat:`** — DTO field, resource and data source attributes, the immutability plan modifier, mock, generated docs, changelog.
2. **`test:`** — alias immutability, secret rotation, and adoption at create time.
3. **`fix!:`** — the redirect URL moves to `status.entraid.redirect_url`. Breaking.
4. **`docs:`** — the schema convention behind commit 3, recorded in the resource-development skill.

## The immutability decision

`idp_alias` is Optional + Computed, with `UseNonNullStateForUnknown` and a plan modifier that **rejects a change** rather than `RequiresReplace`.

meshStack deletes the Keycloak identity provider when an Entra ID integration is deleted, and records nothing about whether the alias was adopted or generated. A destroy-and-recreate would therefore delete a provider the customer configured themselves and registered a redirect URL for. Editing one string should not be able to do that, so the plan fails with an actionable error instead. Same pattern as `version_spec` in `building_block_definition_resource.go:401-415`; the framework ships no equivalent modifier, and a validator cannot see prior state.

## Why the redirect URL moved

`spec.config.entraid.redirect_url` → `status.entraid.redirect_url`.

meshStack derives the URL, so it belongs in a fully computed container. In `spec` it is unreachable under `mock_provider` and cannot be supplied by `override_*` either, which makes any module wiring that reads it untestable (#272). It was also Optional as well as Computed, and meshStack ignores a supplied value, so a configuration that set it failed the apply with `Provider produced inconsistent result after apply` — after creating the integration.

Nested per integration type, mirroring how `status.workload_identity_federation` nests per cloud, so further derived Entra ID values have somewhere to go.

## Verification

Unit suite (mock), `task lint` and the acceptance suite green; docs regenerated with `task generate`. All four commits build and vet on their own.

`05_entra_id_adopt_mock_only` is skipped against a real backend on purpose — a fixed alias cannot be re-adopted across runs, since meshStack rejects one another integration already uses.

## Backward compatibility

`idp_alias` is additive and optional, with no state upgrader. The redirect URL move is breaking for anyone reading the old path; the changelog names it.

Nothing in `meshstack-hub`, `internal-cloudfoundation`, `likvid-cloudfoundation` or `trial-cloudfoundation` configures an `entraid` integration, and every reference into `meshstack_integrations` there goes through `workload_identity_federation.*`. Verified by validating all four config shapes against the built provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
