### PR TITLE
feat: support optional Building Block Definition inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.25.1
+
+FEATURES:
+- `meshstack_building_block_definition`: new `version_spec.inputs.*.is_optional` argument. An optional input may be left blank by whoever fills the building block in; meshStack then sends no value and the implementation falls back to the default declared in its own code — a Terraform variable's `default`, a GitHub workflow input's `default`. It defaults to `false`, so nothing changes for an input you do not declare optional. Marking an input optional needs meshStack 2026.35.0 or later; an older backend silently ignores the field, which surfaces as Terraform's *"Provider produced inconsistent result after apply"* on `is_optional`. The provider mirrors the backend's four rules at plan time instead of letting them fail during apply: an optional input is rejected on the `manual` implementation, for any `assignment_type` other than `USER_INPUT` or `PLATFORM_OPERATOR_MANUAL_INPUT`, for type `BOOLEAN`, and together with a `default_value`. Existing versions keep their `content_hash`, so adding the attribute does not re-run any already-released building block.
+
 # v0.25.0
 
 Requires meshStack 2026.34.0 or later (previously 2026.30.0).

--- a/client/building_block_definition_version.go
+++ b/client/building_block_definition_version.go
@@ -97,6 +97,7 @@ type MeshBuildingBlockDefinitionInput struct {
 	Argument                    types.SecretOrAny `json:"argument" tfsdk:"argument"`
 	DefaultValue                types.SecretOrAny `json:"defaultValue" tfsdk:"default_value"`
 	UpdateableByConsumer        bool              `json:"updateableByConsumer" tfsdk:"updateable_by_consumer"`
+	IsOptional                  bool              `json:"isOptional,omitempty" tfsdk:"is_optional"`
 	SelectableValues            types.Set[string] `json:"selectableValues,omitempty" tfsdk:"selectable_values"`
 	Description                 *string           `json:"description,omitempty" tfsdk:"description"`
 	ValueValidationRegex        *string           `json:"valueValidationRegex,omitempty" tfsdk:"value_validation_regex"`

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -63,6 +63,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         type              = "SINGLE_SELECT"
         assignment_type   = "USER_INPUT"
         selectable_values = ["dev", "prod", "staging"] # Optional, must be non-empty
+        is_optional       = true                       # Optional: defaults to false
         display_order     = 1
       }
       resource_name = {
@@ -600,6 +601,7 @@ Optional:
 - `description` (String) Description explaining the purpose and usage of the input.
 - `display_order` (Number) Numeric value controlling in which order the inputs are displayed in the UI. Cannot be changed on a released version. When omitted, uses the existing value from state, if any. Otherwise the backend assigns one (`0` for a newly declared input).
 - `is_environment` (Boolean) Whether this input is exposed as an environment variable (when `true`) or as a regular variable (when `false`).
+- `is_optional` (Boolean) Whether the input may be left unset when a building block is filled in. meshStack then sends no value and your implementation falls back to the default declared in its own code, e.g. the Terraform variable's `default` or the GitHub workflow input's `default`. **Only supported** for `assignment_type` `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, and **not** for type `BOOLEAN` or for the `manual` implementation. **Mutually exclusive** with `default_value` and `sensitive.default_value`, which would defeat the purpose. Requires meshStack 2026.XX.X or later.
 - `selectable_values` (Set of String) Set of allowed values for the input. **Required** to be non-empty when `type` is `SINGLE_SELECT` or `MULTI_SELECT`.
 - `sensitive` (Attributes) Configuration for sensitive input values. **Mutually exclusive** with the non-sensitive `argument` and `default_value` attributes. When an input is marked as sensitive, use the nested `sensitive.argument` or `sensitive.default_value` instead of the top-level attributes. You can provide an empty attribute `sensitive = {}` to mark this input as sensitive without providing values. Sensitive inputs are **only supported** for `assignment_type` of `USER_INPUT`, `PLATFORM_OPERATOR_MANUAL_INPUT`, `STATIC`. (see [below for nested schema](#nestedatt--version_spec--inputs--sensitive))
 - `updateable_by_consumer` (Boolean) Whether the input value can be updated by consumers without admin or platform operator permissions.

--- a/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
+++ b/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
@@ -45,6 +45,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
         type              = "SINGLE_SELECT"
         assignment_type   = "USER_INPUT"
         selectable_values = ["dev", "prod", "staging"] # Optional, must be non-empty
+        is_optional       = true                       # Optional: defaults to false
         display_order     = 1
       }
       resource_name = {

--- a/internal/provider/building_block_definition_resource.go
+++ b/internal/provider/building_block_definition_resource.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/meshcloud/terraform-provider-meshstack/client"
+	"github.com/meshcloud/terraform-provider-meshstack/client/types/enum"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/generic"
 	"github.com/meshcloud/terraform-provider-meshstack/internal/types/secret"
 )
@@ -188,6 +190,8 @@ func (r *buildingBlockDefinitionResource) ValidateConfig(ctx context.Context, re
 		return
 	}
 
+	validateOptionalInputs(manual, inputs, inputsPath, &resp.Diagnostics)
+
 	// Nothing declared -> nothing to validate (the outputs schema is optional+computed).
 	if outputs.IsNull() || outputs.IsUnknown() {
 		return
@@ -273,6 +277,65 @@ func (r *buildingBlockDefinitionResource) ValidateConfig(ctx context.Context, re
 				"manual building block output override has no effect",
 				fmt.Sprintf("Output %q does not override anything: set assignment_type to a value other than %s, or a display_name "+
 					"that differs from the matching input's. Overriding display_order alone is not supported.", key, none))
+		}
+	}
+}
+
+// validateOptionalInputs re-imposes the backend's rules for an optional input at plan time.
+func validateOptionalInputs(manual types.Object, inputs types.Map, inputsPath path.Path, diags *diag.Diagnostics) {
+	if inputs.IsNull() || inputs.IsUnknown() {
+		return
+	}
+	supportedAssignmentTypes := enum.Of(
+		client.MeshBuildingBlockInputAssignmentTypeUserInput,
+		client.MeshBuildingBlockInputAssignmentTypePlatformOperatorManualInput,
+	)
+	for key, elem := range inputs.Elements() {
+		obj, ok := elem.(types.Object)
+		if !ok || obj.IsNull() || obj.IsUnknown() {
+			continue
+		}
+		attrs := obj.Attributes()
+		if optional, ok := attrs["is_optional"].(types.Bool); !ok || optional.IsNull() || optional.IsUnknown() || !optional.ValueBool() {
+			continue
+		}
+		optionalPath := inputsPath.AtMapKey(key).AtName("is_optional")
+
+		if !manual.IsNull() && !manual.IsUnknown() {
+			diags.AddAttributeError(optionalPath,
+				"input cannot be optional on a manual building block definition",
+				fmt.Sprintf("Input %q is optional, but a manual building block has no implementation to fall back to when an "+
+					"input is left unset. Remove 'is_optional', or use an automated implementation.", key))
+		}
+
+		if assignment := outputStringAttr(attrs, "assignment_type"); !assignment.IsNull() && !assignment.IsUnknown() &&
+			!slices.Contains(supportedAssignmentTypes.Strings(), assignment.ValueString()) {
+			diags.AddAttributeError(optionalPath,
+				"input cannot be optional with this assignment_type",
+				fmt.Sprintf("Input %q is optional, which is only supported for assignment types %s. Its assignment_type is %q.",
+					key, strings.Join(supportedAssignmentTypes.Strings(), ", "), assignment.ValueString()))
+		}
+
+		if inputType := outputStringAttr(attrs, "type"); inputType.ValueString() == client.MeshBuildingBlockIOTypeBoolean.String() {
+			diags.AddAttributeError(optionalPath,
+				"input of type BOOLEAN cannot be optional",
+				fmt.Sprintf("Input %q is optional, but an unset %s is indistinguishable from false by the time it reaches the "+
+					"implementation, so optionality would mean nothing there.", key, client.MeshBuildingBlockIOTypeBoolean))
+		}
+
+		defaultValueSet := func(attrs map[string]attr.Value, name string) bool {
+			v := attrs[name]
+			return v != nil && !v.IsNull() && !v.IsUnknown()
+		}
+		hasDefault := defaultValueSet(attrs, "default_value")
+		if sensitive, ok := attrs["sensitive"].(types.Object); ok && !sensitive.IsNull() && !sensitive.IsUnknown() {
+			hasDefault = hasDefault || defaultValueSet(sensitive.Attributes(), "default_value")
+		}
+		if hasDefault {
+			diags.AddAttributeError(optionalPath,
+				"optional input must not have a default value",
+				fmt.Sprintf("Input %q is optional and also declares a default_value. An optional input that is left unset falls "+
+					"back to the default declared in the implementation's own code, so a meshStack default value would never apply.", key))
 		}
 	}
 }

--- a/internal/provider/building_block_definition_resource_schema.go
+++ b/internal/provider/building_block_definition_resource_schema.go
@@ -145,6 +145,21 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 					Computed:            true,
 					Default:             booldefault.StaticBool(false),
 				},
+				"is_optional": schema.BoolAttribute{
+					MarkdownDescription: "Whether the input may be left unset when a building block is filled in. " +
+						"meshStack then sends no value and your implementation falls back to the default declared in its own code, " +
+						"e.g. the Terraform variable's `default` or the GitHub workflow input's `default`. " +
+						"**Only supported** for `assignment_type` " + enum.Of(
+						client.MeshBuildingBlockInputAssignmentTypeUserInput,
+						client.MeshBuildingBlockInputAssignmentTypePlatformOperatorManualInput,
+					).Markdown() + ", and **not** for type " + client.MeshBuildingBlockIOTypeBoolean.Markdown() +
+						" or for the `manual` implementation. " +
+						"**Mutually exclusive** with `default_value` and `sensitive.default_value`, which would defeat the purpose. " +
+						"Requires meshStack 2026.XX.X or later.", // TODO pinpoint to exact version when released
+					Optional: true,
+					Computed: true,
+					Default:  booldefault.StaticBool(false),
+				},
 				"selectable_values": schema.SetAttribute{
 					MarkdownDescription: "Set of allowed values for the input. **Required** to be non-empty when `type` is " + client.MeshBuildingBlockIOTypeSingleSelect.Markdown() + " or " + client.MeshBuildingBlockIOTypeMultiSelect.Markdown() + ".",
 					ElementType:         types.StringType,

--- a/internal/provider/building_block_definition_resource_test.go
+++ b/internal/provider/building_block_definition_resource_test.go
@@ -1076,6 +1076,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":        knownvalue.StringExact("USER_INPUT"),
 					"is_environment":         knownvalue.Bool(false),
 					"updateable_by_consumer": knownvalue.Bool(false),
+					"is_optional":            knownvalue.Bool(true),
 					"description":            knownvalue.StringExact("The target environment"),
 					"selectable_values": knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.StringExact("dev"),
@@ -1095,6 +1096,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("USER_INPUT"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(true),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.StringExact("Name of the resource to create"),
 					"argument":                       knownvalue.Null(),
 					"default_value":                  knownvalue.StringExact(`"some-resource-name"`),
@@ -1110,6 +1112,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":        knownvalue.StringExact("STATIC"),
 					"is_environment":         knownvalue.Bool(true),
 					"updateable_by_consumer": knownvalue.Bool(false),
+					"is_optional":            knownvalue.Bool(false),
 					"description":            knownvalue.StringExact("Really secret"),
 					"sensitive": xknownvalue.MapExact(map[string]knownvalue.Check{
 						"argument": xknownvalue.MapExact(map[string]knownvalue.Check{
@@ -1132,6 +1135,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("STATIC"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(false),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.Null(),
 					"argument":                       xknownvalue.NotEmptyString(),
 					"default_value":                  knownvalue.Null(),
@@ -1170,6 +1174,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("USER_INPUT"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(false),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.Null(),
 					"selectable_values":              knownvalue.Null(),
 					"value_validation_regex":         knownvalue.Null(),
@@ -1203,6 +1208,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("PLATFORM_OPERATOR_MANUAL_INPUT"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(false),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.Null(),
 					"selectable_values":              knownvalue.Null(),
 					"value_validation_regex":         knownvalue.Null(),
@@ -1218,6 +1224,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("USER_INPUT"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(false),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.Null(),
 					"selectable_values":              knownvalue.Null(),
 					"value_validation_regex":         knownvalue.Null(),
@@ -1254,6 +1261,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("USER_INPUT"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(false),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.Null(),
 					"selectable_values":              knownvalue.Null(),
 					"value_validation_regex":         knownvalue.Null(),
@@ -1287,6 +1295,7 @@ func checksForImplementation(exampleSuffix string) (checkInputs, checkImplementa
 					"assignment_type":                knownvalue.StringExact("USER_INPUT"),
 					"is_environment":                 knownvalue.Bool(false),
 					"updateable_by_consumer":         knownvalue.Bool(false),
+					"is_optional":                    knownvalue.Bool(false),
 					"description":                    knownvalue.Null(),
 					"selectable_values":              knownvalue.Null(),
 					"value_validation_regex":         knownvalue.Null(),
@@ -1464,6 +1473,100 @@ resource "meshstack_building_block_definition" "test" {
 			step := resource.TestStep{
 				Config: symbolConfig(tt.symbol),
 			}
+			if tt.expectError != nil {
+				step.ExpectError = tt.expectError
+			}
+			ApplyAndTest(t, resource.TestCase{
+				Steps: []resource.TestStep{step},
+			})
+		})
+	}
+}
+
+func TestAccBuildingBlockDefinitionOptionalInputValidation(t *testing.T) {
+	// The rules an optional input has to satisfy are mirrored client-side, so they surface at plan time
+	// instead of as a backend 400 during apply.
+	if !IsMockClientTest() {
+		t.Skip("optional input validation is tested with mock client only")
+	}
+
+	t.Parallel()
+
+	const terraformImplementation = `{ terraform = { terraform_version = "1.9.0", repository_url = "https://github.com/example/bb.git" } }`
+	const manualImplementation = `{ manual = {} }`
+
+	config := func(implementation, input string) string {
+		return fmt.Sprintf(`
+resource "meshstack_building_block_definition" "test" {
+  metadata = { owned_by_workspace = "my-workspace" }
+  spec     = { display_name = "Test", description = "Test" }
+  version_spec = {
+    draft          = true
+    inputs         = { candidate = %s }
+    implementation = %s
+  }
+}`, input, implementation)
+	}
+
+	tests := []struct {
+		name           string
+		implementation string
+		input          string
+		expectError    *regexp.Regexp
+	}{
+		{
+			// A manual building block is carried out by a person, so there is no code to fall back to.
+			name:           "optional input rejected on manual implementation",
+			implementation: manualImplementation,
+			input:          `{ display_name = "Candidate", type = "STRING", assignment_type = "USER_INPUT", is_optional = true }`,
+			expectError:    regexp.MustCompile(`cannot be optional on a manual building block`),
+		},
+		{
+			// Optionality is a decision of whoever fills the input in, so only their assignment types qualify.
+			name:           "optional input rejected for a non-user assignment type",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "STRING", assignment_type = "STATIC", argument = jsonencode("c"), is_optional = true }`,
+			expectError:    regexp.MustCompile(`cannot be optional with this assignment_type`),
+		},
+		{
+			name:           "optional BOOLEAN input rejected",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "BOOLEAN", assignment_type = "USER_INPUT", is_optional = true }`,
+			expectError:    regexp.MustCompile(`type BOOLEAN cannot be optional`),
+		},
+		{
+			name:           "optional input with default_value rejected",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "STRING", assignment_type = "USER_INPUT", is_optional = true, default_value = jsonencode("c") }`,
+			expectError:    regexp.MustCompile(`must not have a default value`),
+		},
+		{
+			name:           "optional input with sensitive default_value rejected",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "STRING", assignment_type = "USER_INPUT", is_optional = true, sensitive = { default_value = { secret_value = "c" } } }`,
+			expectError:    regexp.MustCompile(`must not have a default value`),
+		},
+		{
+			name:           "optional USER_INPUT accepted",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "STRING", assignment_type = "USER_INPUT", is_optional = true }`,
+		},
+		{
+			name:           "optional PLATFORM_OPERATOR_MANUAL_INPUT accepted",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "STRING", assignment_type = "PLATFORM_OPERATOR_MANUAL_INPUT", is_optional = true }`,
+		},
+		{
+			// None of the rules applies to an input that is not optional.
+			name:           "non-optional BOOLEAN with default_value accepted",
+			implementation: terraformImplementation,
+			input:          `{ display_name = "Candidate", type = "BOOLEAN", assignment_type = "USER_INPUT", default_value = jsonencode(true) }`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := resource.TestStep{Config: config(tt.implementation, tt.input)}
 			if tt.expectError != nil {
 				step.ExpectError = tt.expectError
 			}

--- a/internal/provider/building_block_definition_version_content_hash_test.go
+++ b/internal/provider/building_block_definition_version_content_hash_test.go
@@ -32,6 +32,10 @@ var (
 	versionSpecNullOutputsChangeJson []byte
 	//go:embed testdata/bbd/version-spec-empty-outputs.json
 	versionSpecEmptyOutputsJson []byte
+	//go:embed testdata/bbd/version-spec-with-isOptional-false.json
+	versionSpecIsOptionalFalseJson []byte
+	//go:embed testdata/bbd/version-spec-with-isOptional.json
+	versionSpecIsOptionalJson []byte
 )
 
 // Test_versionContentHash pins the raw digest (hashValue) each fixture produces under the *current* hashing
@@ -52,6 +56,7 @@ func Test_versionContentHash(t *testing.T) {
 		digestRelevant     = "6ddbadbe5eb3baa76e7a2488f22ce62bd0e94eb380cbfbd55724231f704264dc"
 		digestNullOutputs  = "1a24f70de617e64fc258ceca4a4b7159ecebd9a95acd4ea40851e443c080038e"
 		digestDisplayOrder = "a7cba4239e3d448387d188d1457bd3e00aa66694244dd6e26e8d7a055c9c4075"
+		digestIsOptional   = "8543e0869e73f8a72779e4cb5a80a0363ecf763d53da46878b41234d7efe18d8"
 	)
 	require.NotEqual(t, digestExample, digestRelevant)
 
@@ -67,6 +72,8 @@ func Test_versionContentHash(t *testing.T) {
 		{"null outputs", versionSpecNullOutputsChangeJson, digestNullOutputs},
 		{"empty outputs hash the same as null outputs", versionSpecEmptyOutputsJson, digestNullOutputs},
 		{"display_order affects the hash", versionSpecWithDisplayOrderJson, digestDisplayOrder},
+		{"isOptional false hashes the same as example", versionSpecIsOptionalFalseJson, digestExample},
+		{"isOptional affects the hash", versionSpecIsOptionalJson, digestIsOptional},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/provider/testdata/bbd/version-spec-with-isOptional-false.json
+++ b/internal/provider/testdata/bbd/version-spec-with-isOptional-false.json
@@ -1,0 +1,84 @@
+{
+  "buildingBlockDefinitionRef": {
+    "uuid": "dummy-uuid-12345",
+    "kind": "meshBuildingBlockDefinition"
+  },
+  "onlyApplyOncePerTenant": false,
+  "deletionMode": "DELETE",
+  "runnerRef": {
+    "uuid": "",
+    "kind": "meshBuildingBlockRunner"
+  },
+  "dependencyDefinitionRefs": [
+    {
+      "uuid": "dep-1",
+      "kind": "meshBuildingBlockDefinition"
+    },
+    {
+      "uuid": "dep-2",
+      "kind": "meshBuildingBlockDefinition"
+    }
+  ],
+  "outputs": {
+    "sign_in_url": {
+      "displayName": "Sign-in URL",
+      "type": "STRING",
+      "assignmentType": "SIGN_IN_URL"
+    },
+    "tenant_id": {
+      "displayName": "Tenant ID",
+      "type": "STRING",
+      "assignmentType": "PLATFORM_TENANT_ID"
+    }
+  },
+  "versionNumber": 1,
+  "state": "DRAFT",
+  "implementation": {
+    "terraform": {
+      "terraformVersion": "1.9.0",
+      "repositoryUrl": "https://github.com/example/building-block.git",
+      "async": false,
+      "repositoryPath": "terraform/modules/example",
+      "refName": "v1.0.0",
+      "sshKnownHost": {
+        "host": "github.com",
+        "keyType": "ssh-rsa",
+        "keyValue": "AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+..."
+      },
+      "useMeshHttpBackendFallback": false,
+      "sshPrivateKey": {
+        "hash": "sha256:-----BEGIN OPENSSH PRIVATE KEY-----\n..."
+      }
+    }
+  },
+  "inputs": {
+    "environment": {
+      "displayName": "Environment",
+      "type": "SINGLE_SELECT",
+      "assignmentType": "USER_INPUT",
+      "isEnvironment": false,
+      "isSensitive": false,
+      "updateableByConsumer": true,
+      "selectableValues": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "description": "The target environment",
+      "isOptional": false
+    },
+    "resource_name": {
+      "displayName": "Resource Name",
+      "type": "BOOLEAN",
+      "assignmentType": "STATIC",
+      "isEnvironment": false,
+      "isSensitive": false,
+      "updateableByConsumer": true,
+      "description": "Name of the resource to create",
+      "valueValidationRegex": "^[a-z0-9-]+$",
+      "validationRegexErrorMessage": "Resource name must contain only lowercase letters, numbers, and hyphens",
+      "argument": true,
+      "defaultValue": true
+    }
+  }
+}

--- a/internal/provider/testdata/bbd/version-spec-with-isOptional.json
+++ b/internal/provider/testdata/bbd/version-spec-with-isOptional.json
@@ -1,0 +1,84 @@
+{
+  "buildingBlockDefinitionRef": {
+    "uuid": "dummy-uuid-12345",
+    "kind": "meshBuildingBlockDefinition"
+  },
+  "onlyApplyOncePerTenant": false,
+  "deletionMode": "DELETE",
+  "runnerRef": {
+    "uuid": "",
+    "kind": "meshBuildingBlockRunner"
+  },
+  "dependencyDefinitionRefs": [
+    {
+      "uuid": "dep-1",
+      "kind": "meshBuildingBlockDefinition"
+    },
+    {
+      "uuid": "dep-2",
+      "kind": "meshBuildingBlockDefinition"
+    }
+  ],
+  "outputs": {
+    "sign_in_url": {
+      "displayName": "Sign-in URL",
+      "type": "STRING",
+      "assignmentType": "SIGN_IN_URL"
+    },
+    "tenant_id": {
+      "displayName": "Tenant ID",
+      "type": "STRING",
+      "assignmentType": "PLATFORM_TENANT_ID"
+    }
+  },
+  "versionNumber": 1,
+  "state": "DRAFT",
+  "implementation": {
+    "terraform": {
+      "terraformVersion": "1.9.0",
+      "repositoryUrl": "https://github.com/example/building-block.git",
+      "async": false,
+      "repositoryPath": "terraform/modules/example",
+      "refName": "v1.0.0",
+      "sshKnownHost": {
+        "host": "github.com",
+        "keyType": "ssh-rsa",
+        "keyValue": "AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+..."
+      },
+      "useMeshHttpBackendFallback": false,
+      "sshPrivateKey": {
+        "hash": "sha256:-----BEGIN OPENSSH PRIVATE KEY-----\n..."
+      }
+    }
+  },
+  "inputs": {
+    "environment": {
+      "displayName": "Environment",
+      "type": "SINGLE_SELECT",
+      "assignmentType": "USER_INPUT",
+      "isEnvironment": false,
+      "isSensitive": false,
+      "updateableByConsumer": true,
+      "selectableValues": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "description": "The target environment",
+      "isOptional": true
+    },
+    "resource_name": {
+      "displayName": "Resource Name",
+      "type": "BOOLEAN",
+      "assignmentType": "STATIC",
+      "isEnvironment": false,
+      "isSensitive": false,
+      "updateableByConsumer": true,
+      "description": "Name of the resource to create",
+      "valueValidationRegex": "^[a-z0-9-]+$",
+      "validationRegexErrorMessage": "Resource name must contain only lowercase letters, numbers, and hyphens",
+      "argument": true,
+      "defaultValue": true
+    }
+  }
+}


### PR DESCRIPTION
:warning: PR parked until optional inputs are released with meshfed-release. There is a TODO in this PR to point to the correct meshStack version this is shipped with.




Exposes the optional-input flag added by meshcloud/meshfed-release#10701 on `meshstack_building_block_definition`, as `version_spec.inputs.*.is_optional`.

An operator can mark a definition input optional, so whoever fills the Building Block in may leave it blank and the implementation falls back to the default declared in its own code — a Terraform variable's `default`, a GitHub workflow input's `default`.

> Supersedes #289, which GitHub closed when this branch was renamed to pair with the meshfed-release branch of the same name.

## What changed

- **Client DTO** — `IsOptional` on `MeshBuildingBlockDefinitionInput`.
- **Schema** — `is_optional` (Optional+Computed, default `false`), matching how `is_environment` and `updateable_by_consumer` are modelled.
- **Plan-time validation** — `validateOptionalInputs` in `ValidateConfig`.
- **Example + generated docs** — the `environment` input of `resource_01_terraform.tf` is now optional, which also exercises the field in the acceptance suite.
- **Tests** — `TestAccBuildingBlockDefinitionOptionalInputValidation` (8 cases, mock-client only, modelled on the manual-outputs validation test), `is_optional` added to the 9 exhaustive input state-check maps, and two content-hash fixtures.

## Merge order

The acceptance job is expected to be **red until meshcloud/meshfed-release#10701 merges**. The backend commit is not on meshfed `develop`, so the `meshfed:latest` service container does not know `isOptional`; the meshObject mapper disables `FAIL_ON_UNKNOWN_PROPERTIES`, so the field is silently dropped and the read-back `false` fails Terraform's consistency check on the two tests that use `resource_01_terraform.tf`. Terraform reports it as *"inconsistent values for sensitive attribute"* because `version_spec` has sensitive descendants.

This branch is named identically to the meshfed-release branch, so meshfed's `terraform-provider-acceptance` job builds backend + provider together and validates the pair before either side merges. Merge the backend PR, let `:latest` rebuild, then re-run acceptance here.

## Notes for a reviewer

**`json:"isOptional,omitempty"` and no `currentHashVersion` bump.** `false` is the backend's default for an absent field, so a non-optional input serialises exactly as it did before the field existed. Every already-stored content hash stays byte-identical, which is what keeps a provider upgrade from re-running released Building Blocks — a v6 bump would have been the alternative. The new fixture `isOptional false hashes the same as example` pins that equality so a later change cannot break it silently. It also means a backend that does not know the field sees an unchanged payload for configs that do not use the feature.

**`MinMeshStackVersion` deliberately stays at 2026.34.0.** Unlike `meshstack_landingzone`'s `spec.restricted` (which the provider always sends and reads, so an older backend broke every apply), this field only reaches the backend for someone who opted in. Gating every user of the provider seemed to cost more than it protects. Instead the schema description and the changelog state the version requirement, and an older backend silently ignoring the field surfaces as the inconsistent-result error described above. Happy to swap this for a version bump if you would rather have the hard gate.

**The four rules are mirrored client-side.** `ValidateConfig` rejects an optional input on the `manual` implementation, for an `assignment_type` other than `USER_INPUT`/`PLATFORM_OPERATOR_MANUAL_INPUT`, for type `BOOLEAN`, and alongside a `default_value` (including `sensitive.default_value`) — so these fail at plan instead of as a 400 mid-apply. Checks whose value is unknown at plan are skipped, so the backend stays the authority. The duplication is the trade-off: if the backend ever loosens a rule, this has to follow.

**Out of scope.** The `meshstack_building_block_definitions` data source exposes no `version_spec` at all, so there was nothing to add there. The instance side — read-only `isOptional`/`isSet` on `meshBuildingBlockV2` inputs and clearing an optional input with `"value": null`, from the same meshfed PR — is untouched and needs its own change to `meshstack_building_block`.

## Open before this leaves draft

- The exact meshStack version for the `2026.XX.X` TODO in the schema description (the CHANGELOG currently names 2026.35.0).
- A green acceptance run against a backend carrying the companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)