### PR TITLE
feat: add an optional building block name template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BREAKING CHANGES:
 
 FEATURES:
 - `meshstack_integration`: new `spec.config.entraid.idp_alias` argument adopts an identity provider that already exists in your meshStack, instead of having meshStack create one. Leave it out and meshStack generates an alias. The alias cannot be changed afterwards, and a plan that changes it fails. `meshstack_integrations` exposes it too.
+- `meshstack_building_block_definition`: new optional `spec.display_name_template` argument, a mustache-like template that names every new building block of the definition after the values it was ordered with, for example `Project {{projectName}}`. Without the argument, a new building block is named after `display_name`. This needs a meshStack that serves the field; an older one leaves it out of its response, so an apply that sets it fails Terraform's consistency check.
 
 # v0.25.0
 

--- a/client/building_block_definition.go
+++ b/client/building_block_definition.go
@@ -24,6 +24,7 @@ type MeshBuildingBlockDefinitionMetadata struct {
 
 type MeshBuildingBlockDefinitionSpec struct {
 	DisplayName           string                `json:"displayName" tfsdk:"display_name"`
+	DisplayNameTemplate   *string               `json:"displayNameTemplate,omitempty" tfsdk:"display_name_template"`
 	TargetType            MeshBuildingBlockType `json:"targetType" tfsdk:"target_type"`
 	Description           string                `json:"description" tfsdk:"description"`
 	Readme                *string               `json:"readme,omitempty" tfsdk:"readme"`

--- a/docs/resources/building_block_definition.md
+++ b/docs/resources/building_block_definition.md
@@ -28,6 +28,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
 
   spec = {
     display_name              = "Example Building Block"
+    display_name_template     = "Example Building Block {{ resource_name }}"                         # Optional: names each ordered building block after its inputs
     symbol                    = provider::meshstack::load_image_file("${path.module}/bb-symbol.png") # Optional
     description               = "An example building block definition"
     readme                    = "# Example Building Block\n\nThis is a comprehensive example showcasing all available attributes." # Optional
@@ -376,6 +377,7 @@ Required:
 
 Optional:
 
+- `display_name_template` (String) Mustache-like template that names every new building block of this definition after the values it was ordered with, for example `Project {{projectName}}`. A placeholder must name an input of the definition and nothing else; if any placeholder cannot be resolved, the building block is named after the unrendered template instead. Without this attribute, a new building block is named after `display_name`. Needs a meshStack that serves the field: an older one leaves it out of its response, so an apply that sets it fails Terraform's consistency check.
 - `documentation_url` (String) URL pointing to documentation for the building block definition.
 - `notification_subscribers` (Set of String) List of subscribers to notify about events related to this building block. Prefix usernames with `user:` and emails with `email:`.
 - `readme` (String) Detailed readme/documentation in markdown format.

--- a/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
+++ b/examples/resources/meshstack_building_block_definition/resource_01_terraform.tf
@@ -10,6 +10,7 @@ resource "meshstack_building_block_definition" "example_01_terraform" {
 
   spec = {
     display_name              = "Example Building Block"
+    display_name_template     = "Example Building Block {{ resource_name }}"                         # Optional: names each ordered building block after its inputs
     symbol                    = provider::meshstack::load_image_file("${path.module}/bb-symbol.png") # Optional
     description               = "An example building block definition"
     readme                    = "# Example Building Block\n\nThis is a comprehensive example showcasing all available attributes." # Optional

--- a/internal/provider/building_block_definition_resource_schema.go
+++ b/internal/provider/building_block_definition_resource_schema.go
@@ -266,6 +266,18 @@ func (r *buildingBlockDefinitionResource) Schema(_ context.Context, _ resource.S
 						MarkdownDescription: "Display name of the building block definition as shown in meshPanel.",
 						Required:            true,
 					},
+					"display_name_template": schema.StringAttribute{
+						MarkdownDescription: "Mustache-like template that names every new building block of this definition after " +
+							"the values it was ordered with, for example `Project {{projectName}}`. A placeholder must name an " +
+							"input of the definition and nothing else; if any placeholder cannot be resolved, the building block " +
+							"is named after the unrendered template instead. Without this attribute, a new building block is " +
+							"named after `display_name`. Needs a meshStack that serves the field: an older one leaves it out of " +
+							"its response, so an apply that sets it fails Terraform's consistency check.",
+						Optional: true,
+						Validators: []validator.String{
+							stringvalidator.LengthAtMost(255),
+						},
+					},
 					"symbol": schema.StringAttribute{
 						MarkdownDescription: "Symbol/icon of the building block definition as shown in meshPanel. " +
 							"This can either be an URL starting with `http[s]://` or a base64 encoded data blob. " +

--- a/internal/provider/building_block_definition_resource_test.go
+++ b/internal/provider/building_block_definition_resource_test.go
@@ -709,6 +709,65 @@ func TestAccBuildingBlockDefinition(t *testing.T) {
 		})
 	})
 
+	// A template can be set, changed, emptied, and dropped again. Both an empty string and a missing
+	// attribute mean the same thing to meshStack - name the building block after the definition - but
+	// Terraform tells them apart, so each has to survive a refresh without leaving a diff behind.
+	t.Run("15_display_name_template_lifecycle", func(t *testing.T) {
+		config, addr := testconfig.BBDManual(t)
+		withNameTemplate := func(template string) testconfig.Config {
+			return config.WithFirstBlock(
+				testconfig.Descend("spec", "display_name_template")(testconfig.SetString(template)),
+			)
+		}
+		nameTemplatePath := tfjsonpath.New("spec").AtMapKey("display_name_template")
+
+		ApplyAndTest(t, resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: withNameTemplate("Block for {{ region }}").String(),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(addr.String(), nameTemplatePath, knownvalue.StringExact("Block for {{ region }}")),
+					},
+				},
+				{
+					Config: withNameTemplate("Block for {{ region }} v2").String(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(addr.String(), plancheck.ResourceActionUpdate),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(addr.String(), nameTemplatePath, knownvalue.StringExact("Block for {{ region }} v2")),
+					},
+				},
+				{
+					Config: withNameTemplate("").String(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(addr.String(), nameTemplatePath, knownvalue.StringExact("")),
+					},
+				},
+				{
+					// Dropping the attribute removes the template, and the refresh has to agree: a state that
+					// still held the old value would leave the same diff on every later plan.
+					Config: config.String(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(addr.String(), nameTemplatePath, knownvalue.Null()),
+					},
+				},
+			},
+		})
+	})
+
 	// Regression test for issue #196: rotating a sensitive input's secret on a released (immutable)
 	// version previously failed with an opaque "Failed to determine content hash ... [plaintext]"
 	// error, because the planned DTO carries the rotated secret's plaintext and the content hash
@@ -983,11 +1042,12 @@ func checkBBDSpecFull(expectedDescription string) knownvalue.Check {
 			}
 			return nil
 		}),
-		"description":       knownvalue.StringExact(expectedDescription),
-		"readme":            xknownvalue.NotEmptyString(),
-		"support_url":       knownvalue.StringExact("https://support.example.com/building-blocks"),
-		"documentation_url": knownvalue.StringExact("https://docs.example.com/building-blocks"),
-		"target_type":       knownvalue.StringExact("TENANT_LEVEL"),
+		"display_name_template": knownvalue.StringExact("Example Building Block {{ resource_name }}"),
+		"description":           knownvalue.StringExact(expectedDescription),
+		"readme":                xknownvalue.NotEmptyString(),
+		"support_url":           knownvalue.StringExact("https://support.example.com/building-blocks"),
+		"documentation_url":     knownvalue.StringExact("https://docs.example.com/building-blocks"),
+		"target_type":           knownvalue.StringExact("TENANT_LEVEL"),
 		"supported_platforms": knownvalue.SetExact([]knownvalue.Check{
 			xknownvalue.MapExact(map[string]knownvalue.Check{
 				"kind": knownvalue.StringExact("meshPlatformType"),
@@ -1016,6 +1076,7 @@ func checkBBDSpecMinimal(expectedDescription string) knownvalue.Check {
 			return nil
 		}),
 		"symbol":                    xknownvalue.NotEmptyString(),
+		"display_name_template":     knownvalue.Null(),
 		"description":               knownvalue.StringExact(expectedDescription),
 		"readme":                    knownvalue.Null(),
 		"support_url":               knownvalue.Null(),


### PR DESCRIPTION
## What

Exposes meshStack's new building block name template as `spec.display_name_template` on
`meshstack_building_block_definition`. It is a mustache-like template that names every new building block
after the values it was ordered with, for example `Project {{projectName}}`. Until now the definition's
`display_name` doubled as that template, so the raw placeholders also leaked into every place meshStack
shows a *definition* name.

Backend counterpart: meshcloud/meshfed-release#10762. **The acceptance tests here fail until that PR is in
`develop`**, because the field does not exist yet on the meshStack this repo's CI targets. That PR's
`tfAcceptanceTest` job tests both halves together, by branch name.

## Semantics

The attribute is a plain optional string and meshStack stores what it receives. No attribute, `null` and
`""` all mean the same thing to meshStack — name the building block after `display_name` — so a template
can be removed either by dropping the attribute or by setting it to `""`. Terraform tells those two apart,
so both round-trip through a refresh without leaving a diff behind.

## Tests

`TestAccBuildingBlockDefinition/15_display_name_template_lifecycle` walks set → change → empty → dropped.
The last two steps each carry a post-refresh `ExpectEmptyPlan`, which is what catches the perpetual-diff
trap that either representation of "no template" could otherwise cause.

`task lint` is clean, the unit-mode suite passes, and the paired `tfAcceptanceTest` against a local
meshStack carrying the backend PR passes (142 tests, 12 skipped). `task generate` refreshed the docs and
the `01_terraform` example.

## Not changed

`meshstack_building_block_definitions` deliberately exposes only the fields you select a definition by
(`display_name`, `target_type`), so the template is not added there.

`MinMeshStackVersion` stays at 2026.34.0. The gate is global and this is an additive optional field, which
`terraform-provider-compat` exempts from the version registry, so raising it would force an upgrade on
every user including those who never set the attribute. A configuration that does set it against a
meshStack that does not serve the field fails the apply on Terraform's consistency check; the CHANGELOG and
the attribute description both say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
